### PR TITLE
Fix a null pointer dereference when wlansvc isn't running

### DIFF
--- a/lib/OperationHandlerBuilder.hpp
+++ b/lib/OperationHandlerBuilder.hpp
@@ -38,8 +38,13 @@ inline std::unique_ptr<OperationHandler> MakeWlansvcOperationHandler(std::shared
                 LOG_CAUGHT_EXCEPTION_MSG("Failed to initialize a wlansvc interface. Skipping it.");
             }
         }
+        return std::make_unique<WlansvcOperationHandler>(std::move(callbacks), std::move(wlanInterfaces), wlansvc);
     }
-    return std::make_unique<WlansvcOperationHandler>(std::move(callbacks), std::move(wlanInterfaces), wlansvc);
+    else
+    {
+        // Without wlansvc, we can't handle interfaces arrival/departures anyway, so an `OperationHandler` is enough
+        return std::make_unique<OperationHandler>(std::move(callbacks), std::move(wlanInterfaces));
+    }
 }
 
 inline std::unique_ptr<OperationHandler> MakeManualTestOperationHandler(ProxyWifiCallbacks callbacks)

--- a/lib/WlansvcOperationHandler.hpp
+++ b/lib/WlansvcOperationHandler.hpp
@@ -18,6 +18,11 @@ public:
     WlansvcOperationHandler(ProxyWifiCallbacks callbacks, std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces, std::shared_ptr<Wlansvc::WlanApiWrapper>& wlansvc)
         : OperationHandler{std::move(callbacks), std::move(wlanInterfaces)}, m_wlansvc{wlansvc}
     {
+        if (!m_wlansvc)
+        {
+            return;
+        }
+
         m_wlansvc->Subscribe(GUID{}, [this](const auto& n) {
             if (n.NotificationSource == WLAN_NOTIFICATION_SOURCE_ACM)
             {
@@ -47,7 +52,10 @@ public:
 
     virtual ~WlansvcOperationHandler()
     {
-        m_wlansvc->Unsubscribe(GUID{});
+        if (m_wlansvc)
+        {
+            m_wlansvc->Unsubscribe(GUID{});
+        }
     }
 
 private:

--- a/test/TestOpHandler.cpp
+++ b/test/TestOpHandler.cpp
@@ -69,6 +69,12 @@ DisconnectRequest MakeDisconnectRequest(uint32_t sessionId)
 
 // Tests for WlansvcOperationHandler.cpp
 
+TEST_CASE("The WlanApiWrapper is optionnal", "[wlansvcOpHandler]")
+{
+    auto opHandler = MakeWlansvcOperationHandler(std::shared_ptr<Wlansvc::WlanApiWrapper>{}, {});
+    CHECK(opHandler);
+}
+
 TEST_CASE("Process a scan requests", "[wlansvcOpHandler]")
 {
     auto body = std::vector<uint8_t>(sizeof(proxy_wifi_scan_request));


### PR DESCRIPTION
### Goals

Fix a null pointer dereference when proxy_wifi is started on a device without wlansvc running.

### Technical Details

Add a check in `WlansvcOperationHandler` constructor and destructor to subscribe to interface arrival and removal notifications only if the handle to `WlanApiWrapper` is non-null.

### Testing

Added a unit test to validate `WlansvcOperationHandler` can be constructed successfully without a `WlanApiWrapper`

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formated with clang-format
- [x] Newly added code include doxygen-style comments
- [x] Unit tests are succeeding
