### PR TITLE
Fix build break related to WIL ingestion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ set(WIL_BUILD_PACKAGING OFF CACHE INTERNAL "Turn off wil packaging")
 FetchContent_Declare(WIL
     GIT_REPOSITORY "https://github.com/microsoft/wil"
     GIT_TAG "f9284c19c9873664978b873b8858d7dfacc6af1e"
-    GIT_SHALLOW ON
+    GIT_SHALLOW OFF
 )
 FetchContent_MakeAvailable(WIL)
 


### PR DESCRIPTION
### Goals

Fix build break related to WIL ingestion.

### Technical Details

Set "GIT_SHALLOW" to "OFF" in Cmake FetchContent.
It prevented Fetch_Content from finding commit different from the latest one.

### Testing

Build is succeeding

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formated with clang-format
- [x] Newly added code include doxygen-style comments
- [x] Unit tests are succeeding
