### PR TITLE
Fix logic to detect if project is a sub project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 
 # Detect if proxy-wifi is being used by another project
-if(NOT PARENT_DIRECTORY)
+if(NOT DEFINED PARENT_DIRECTORY)
     set(PROXY_WIFI_NOT_SUBPROJECT ON)
 endif()
 


### PR DESCRIPTION
### Goals

This changes corrects the logic to detect if this project is used as a subproject.

### Technical Details

This allow consumers to skip building the tests and cmdline projects.

### Testing

The still projects builds all targets when it's not used as a subproject 



### Checklist

- [X] All targets compile successfully
- [ ] Changes have been formated with clang-format
- [ ] Newly added code include doxygen-style comments
- [ ] Unit tests are succeeding
