### PR TITLE
Add missing exception handling

### DIFF
--- a/lib/Transport.cpp
+++ b/lib/Transport.cpp
@@ -104,7 +104,13 @@ void Transport::AcceptConnections()
 
 void Transport::QueueNotification(Message&& msg)
 {
-    m_notifQueue.Submit([this, n = std::move(msg)]() noexcept { SendNotification(std::move(n)); });
+    m_notifQueue.Submit([this, n = std::move(msg)]() noexcept {
+        try
+        {
+            SendNotification(std::move(n));
+        }
+        CATCH_LOG_MSG("Failed to send a notification")
+    });
 }
 
 void Transport::SendNotification(const Message& message)


### PR DESCRIPTION
### Goals

Fix a fail fast when an hv_socket fails to connect to the guest to send a notification.

### Technical Details

The exception thrown when the socket failed to connect would propagate up to a `noexcept` lambda, causing the process to fail fast.
The fix is to catch and log the exception: the error is not fatal, and more complex error handling is not needed (the cause of the failure is likely the guest isn't listening).

### Testing

Manual reproduction of the error using the test mode by:
- connecting
- stopping proxy_wifi in the VM
- manually sending a notification

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formated with clang-format
- [ ] Newly added code include doxygen-style comments
- [x] Unit tests are succeeding
