### PR TITLE
Send client notifications from a separate workqueue

### DIFF
--- a/lib/OperationHandler.cpp
+++ b/lib/OperationHandler.cpp
@@ -422,4 +422,10 @@ ScanResponse OperationHandler::HandleScanRequest(const ScanRequest& scanRequest)
     return m_serializedRunner.RunAndWait([&] { return HandleScanRequestSerialized(scanRequest); });
 }
 
+void OperationHandler::DrainClientNotifications()
+{
+    // Wait for a task doing nothing: this ensure all previous notification have been processed
+    m_clientNotificationQueue.RunAndWait([] { return; });
+}
+
 } // namespace ProxyWifi

--- a/lib/OperationHandler.cpp
+++ b/lib/OperationHandler.cpp
@@ -64,7 +64,7 @@ void OperationHandler::SendGuestNotification(std::variant<DisconnectNotif, Signa
     }
 }
 
-void OperationHandler::NotifyConnectionToClient(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network, DOT11_AUTH_ALGORITHM authAlgo)
+void OperationHandler::NotifyConnectionToClientSerialized(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network, DOT11_AUTH_ALGORITHM authAlgo)
 {
     Log::Info(
         L"Notifying a connection to client. Source: %ws, Interface: %ws, Ssid: %ws, Auth Algo: %ws",
@@ -79,7 +79,7 @@ void OperationHandler::NotifyConnectionToClient(EventSource source, const GUID& 
     }
 }
 
-void OperationHandler::NotifyDisconnectionToClient(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network)
+void OperationHandler::NotifyDisconnectionToClientSerialized(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network)
 {
     Log::Info(
         L"Notifying a disconnection to client. Source: %ws, Interface: %ws, Ssid: %ws",
@@ -93,26 +93,44 @@ void OperationHandler::NotifyDisconnectionToClient(EventSource source, const GUI
     }
 }
 
+void OperationHandler::NotifyConnectionToClient(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network, DOT11_AUTH_ALGORITHM authAlgo)
+{
+    m_clientNotificationQueue.RunAndWait([this, source, interfaceGuid, network, authAlgo] {
+        NotifyConnectionToClientSerialized(source, interfaceGuid, network, authAlgo);
+    });
+}
+
+void OperationHandler::NotifyDisconnectionToClient(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network)
+{
+    m_clientNotificationQueue.RunAndWait(
+        [this, source, interfaceGuid, network] { NotifyDisconnectionToClientSerialized(source, interfaceGuid, network); });
+}
+
 void OperationHandler::NotifyGuestConnectRequestProgress(GuestConnectStatus status)
 {
-    Log::Info(L"Notifying guest directed connection progress to the client. Status: %ws", GuestConnectStatusToString(status));
+    m_clientNotificationQueue.RunAndWait([this, status] {
+        Log::Info(L"Notifying guest directed connection progress to the client. Status: %ws", GuestConnectStatusToString(status));
 
-    if (m_clientCallbacks.OnGuestConnectRequestProgress)
-    {
-        m_clientCallbacks.OnGuestConnectRequestProgress(status);
-    }
+        if (m_clientCallbacks.OnGuestConnectRequestProgress)
+        {
+            m_clientCallbacks.OnGuestConnectRequestProgress(status);
+        }
+    });
 }
 
 void OperationHandler::OnHostConnection(const GUID& interfaceGuid, const Ssid& ssid, DOT11_AUTH_ALGORITHM authAlgo)
 {
     // Always notify the client on a new host connection
-    NotifyConnectionToClient(EventSource::Host, interfaceGuid, ssid, authAlgo);
+    m_clientNotificationQueue.Run([this, interfaceGuid, ssid, authAlgo] {
+        NotifyConnectionToClientSerialized(EventSource::Host, interfaceGuid, ssid, authAlgo);
+    });
 }
 
 void OperationHandler::OnHostDisconnection(const GUID& interfaceGuid, const Ssid& ssid)
 {
     // Notify the client first
-    NotifyDisconnectionToClient(EventSource::Host, interfaceGuid, ssid);
+    m_clientNotificationQueue.Run(
+        [this, interfaceGuid, ssid] { NotifyDisconnectionToClientSerialized(EventSource::Host, interfaceGuid, ssid); });
 
     // If this is a spontaneous disconnection from the host on the interface currently used by the guest,
     // send a disconnect notification to the guest and mark it as disconnected
@@ -134,7 +152,8 @@ void OperationHandler::OnHostSignalQualityChange(const GUID& interfaceGuid, unsi
 {
     // Only forward notification for the currently connected interface to the guest
     m_serializedRunner.Run([this, interfaceGuid, signalQuality] {
-        if (m_guestConnection && interfaceGuid == m_guestConnection->interfaceGuid) {
+        if (m_guestConnection && interfaceGuid == m_guestConnection->interfaceGuid)
+        {
             Log::Trace(L"Send Signal quality change notification to the guest, Signal quality: %d", signalQuality);
             SendGuestNotification(SignalQualityNotif{Wlansvc::LinkQualityToRssi(signalQuality)});
         }

--- a/lib/OperationHandler.hpp
+++ b/lib/OperationHandler.hpp
@@ -56,6 +56,10 @@ public:
     void RegisterGuestNotificationCallback(GuestNotificationCallback notificationCallback);
     void ClearGuestNotificationCallback();
 
+    /// @brief Wait all client notifications have been processed and return
+    /// Unit test helper
+    void DrainClientNotifications();
+
 protected:
 
     /// @brief Must be called by the interfaces when they connect to a network

--- a/lib/OperationHandler.hpp
+++ b/lib/OperationHandler.hpp
@@ -77,6 +77,9 @@ private:
     /// @brief Send a notification to the guest
     void SendGuestNotification(std::variant<DisconnectNotif, SignalQualityNotif> notif);
 
+    void NotifyConnectionToClientSerialized(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network, DOT11_AUTH_ALGORITHM authAlgo);
+    void NotifyDisconnectionToClientSerialized(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network);
+
     /// @brief Notify the lib user that the host/guest connected
     void NotifyConnectionToClient(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network, DOT11_AUTH_ALGORITHM authAlgo);
 
@@ -124,6 +127,7 @@ private:
     std::vector<std::unique_ptr<IWlanInterface>> m_wlanInterfaces;
 
     SerializedWorkRunner m_serializedRunner;
+    SerializedWorkRunner m_clientNotificationQueue;
 };
 
 } // namespace ProxyWifi


### PR DESCRIPTION
### Goals

Prevent clients from deadlocking if they hold a lock when creating the proxy and notification callbacks.
Also ensure all client notifications are serialized.

### Technical Details

Send notifications from a separate work queue. Keep waiting on guest related notifications as before, since the client uses this to control when the guest will receive its answer.

### Testing

Added unit test, passing.

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formated with clang-format
- [x] Newly added code include doxygen-style comments
- [x] Unit tests are succeeding
