### PR TITLE
Add notifications on scan and refactor the notification callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,18 +95,21 @@ You can additionnaly setup a logger to chose where logs will be output.
     // Tell the ProxyWifiService to output logs to a tracelogging provider
     Log::AddLogger(std::make_unique<Log::TraceLoggingLogger>());
 
-    // Callback executed on a connection event
-    auto onConnect = [this](EventSource origin, const OnConnectionArgs& args) -> void { ... };
-    // Callback executed on a disconnection event
-    auto onDisconnect = [this](EventSource origin, const OnDisconnectionArgs& args) -> void { ... };
-    // Callback executed on the guest connection request that will cause a host interface to connect
-    auto onGuestConnectRequest = [this](GuestConnectStatus status) -> void { ... };
+    class MyObserver: public ProxyWifiObserver
+    {
+        void OnGuestConnectionRequest(OperationType type, const DOT11_SSID& ssid) noexcept override
+        {
+            std::cout << "The guest requested a connection" << std::endl;
+        }
+    };
+
     // Callback providing a list of networks that will be simulated by the Wi-Fi proxy
     auto provideFakeNetworks = [this]() -> std::vector<WifiNetworkInfo> { return ... };
 
     m_wifiProxy = BuildProxyWifiService(
         ProxyWifiHyperVSettings{vmId},
-        ProxyWifiCallbacks{std::move(onConnect), std::move(onDisconnect), std::move(onGuestConnectRequest), std::move(provideFakeNetworks)});
+        std::move(provideFakeNetworks),
+        std::make_shared<MyObserver>());
     m_wifiProxy->Start();
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,14 +103,17 @@ You can additionnaly setup a logger to chose where logs will be output.
         }
     };
 
+    // Must be kept alive until the proxy is destroyed
+    auto observer = MyObserver{};
+
     // Callback providing a list of networks that will be simulated by the Wi-Fi proxy
     auto provideFakeNetworks = [this]() -> std::vector<WifiNetworkInfo> { return ... };
 
-    m_wifiProxy = BuildProxyWifiService(
+    auto wifiProxy = BuildProxyWifiService(
         ProxyWifiHyperVSettings{vmId},
         std::move(provideFakeNetworks),
-        std::make_shared<MyObserver>());
-    m_wifiProxy->Start();
+        &observer);
+    wifiProxy->Start();
 ```
 
 ## Architecture

--- a/include/ProxyWifi/ProxyWifiService.hpp
+++ b/include/ProxyWifi/ProxyWifiService.hpp
@@ -240,8 +240,8 @@ struct ProxyWifiTcpSettings
 };
 
 std::unique_ptr<ProxyWifiService> BuildProxyWifiService(
-    const ProxyWifiHyperVSettings& settings, FakeNetworkProvider fakeNetworkCallback = {}, std::shared_ptr<ProxyWifiObserver> observer = {});
+    const ProxyWifiHyperVSettings& settings, FakeNetworkProvider fakeNetworkCallback = {}, ProxyWifiObserver* pObserver = nullptr);
 std::unique_ptr<ProxyWifiService> BuildProxyWifiService(
-    const ProxyWifiTcpSettings& settings, FakeNetworkProvider fakeNetworkCallback = {}, std::shared_ptr<ProxyWifiObserver> observer = {});
+    const ProxyWifiTcpSettings& settings, FakeNetworkProvider fakeNetworkCallback = {}, ProxyWifiObserver* pObserver = nullptr);
 
 } // namespace ProxyWifi

--- a/include/ProxyWifi/ProxyWifiService.hpp
+++ b/include/ProxyWifi/ProxyWifiService.hpp
@@ -87,15 +87,19 @@ struct OnDisconnectionArgs {
     DOT11_SSID disconnectedNetwork{};
 };
 
+/// @brief Indicate the impact a guest requested operation will have on the host
 enum class OperationType
 {
-    GuestDirected,
-    HostMirroring
+    GuestDirected, ///< The guest is directing this operation, and the host state will change to accomodate it
+    HostMirroring ///< The guest was only replicating the state of the host, the host state won't change as a result of this request
 };
 
 // Temporarily disable the "unused argument warning"
 #pragma warning(push)
 #pragma warning(disable : 4100)
+
+/// @brief Observer class that get notified on host or guest events
+/// Client should inherit from it and override method to handle notifications
 class ProxyWifiObserver
 {
 public:
@@ -104,6 +108,7 @@ public:
         DOT11_SSID ssid;
         DOT11_AUTH_ALGORITHM authAlgo;
     };
+
     struct DisconnectCompleteArgs {
         GUID interfaceGuid;
         DOT11_SSID ssid;

--- a/include/ProxyWifi/ProxyWifiService.hpp
+++ b/include/ProxyWifi/ProxyWifiService.hpp
@@ -94,19 +94,23 @@ enum class OperationType
     HostMirroring ///< The guest was only replicating the state of the host, the host state won't change as a result of this request
 };
 
-// Temporarily disable the "unused argument warning"
-#pragma warning(push)
-#pragma warning(disable : 4100)
-
 /// @brief Observer class that get notified on host or guest events
 /// Client should inherit from it and override method to handle notifications
 class ProxyWifiObserver
 {
 public:
+    struct ConnectRequestArgs {
+        DOT11_SSID ssid;
+    };
+
     struct ConnectCompleteArgs {
         GUID interfaceGuid;
         DOT11_SSID ssid;
         DOT11_AUTH_ALGORITHM authAlgo;
+    };
+
+    struct DisconnectRequestArgs {
+        DOT11_SSID ssid;
     };
 
     struct DisconnectCompleteArgs {
@@ -115,19 +119,19 @@ public:
     };
 
     /// @brief An host WiFi interface connected to a network
-    virtual void OnHostConnection(const ConnectCompleteArgs& connectionInfo) noexcept
+    virtual void OnHostConnection(const ConnectCompleteArgs& /* connectionInfo */) noexcept
     {
     }
 
     /// @brief An host WiFi interface disconnected from a network
-    virtual void OnHostDisconnection(const DisconnectCompleteArgs& disconnectionInfo) noexcept
+    virtual void OnHostDisconnection(const DisconnectCompleteArgs& /* disconnectionInfo */) noexcept
     {
     }
 
     /// @brief The guest requested a connection to a network
     /// If `type == OperationType::HostMirroring`, an host inteface is already connected to the network, otherwise, one will be
     /// connected The connection won't proceed until the callback returns
-    virtual void OnGuestConnectionRequest(OperationType type, const DOT11_SSID& ssid) noexcept
+    virtual void OnGuestConnectionRequest(OperationType /* type */, const ConnectRequestArgs& /* connectionInfo */) noexcept
     {
     }
 
@@ -135,21 +139,21 @@ public:
     /// If `type == OperationType::HostMirroring`, an host inteface was already connected to the network, otherwise, one has been be connected
     /// The response won't be sent to the guest until this callback returns
     virtual void OnGuestConnectionCompletion(
-        OperationType type, OperationStatus status, const ConnectCompleteArgs& connectionInfo) noexcept
+        OperationType /* type */, OperationStatus /* status */, const ConnectCompleteArgs& /* connectionInfo */) noexcept
     {
     }
 
     /// @brief The guest requested a disconnection from the connected network
     /// If `type == OperationType::HostMirroring`, the host won't be impacted, otherwise, a matching host interface will be disconnected
     /// The disconnection won't proceed until the callback returns
-    virtual void OnGuestDisconnectionRequest(OperationType type, DOT11_SSID ssid) noexcept
+    virtual void OnGuestDisconnectionRequest(OperationType /* type */, const DisconnectRequestArgs& /* connectionInfo */) noexcept
     {
     }
 
     /// @brief A guest disconnection request was processed
     /// If `type == OperationType::HostMirroring`, this was a no-op for the host, otherwise, a matching host interface has been disconnected
     /// The response won't be sent to the guest until this callback returns
-    virtual void OnGuestDisconnectionCompletion(OperationType type, OperationStatus status, const DisconnectCompleteArgs& disconnectionInfo) noexcept
+    virtual void OnGuestDisconnectionCompletion(OperationType /* type */, OperationStatus /* status */, const DisconnectCompleteArgs& /* disconnectionInfo */) noexcept
     {
     }
 
@@ -161,12 +165,10 @@ public:
 
     /// @brief A guest scan request was processed
     /// The scan results won't be sent to the guest until this callback returns
-    virtual void OnGuestScanCompletion(OperationStatus status) noexcept
+    virtual void OnGuestScanCompletion(OperationStatus /* status */) noexcept
     {
     }
 };
-
-#pragma warning(pop)
 
 /// @brief Type of the callback providing a list of networks that will be simulated by the Wi-Fi proxy
 /// They will be shown as open networks, and are considered as permanently connected for the purpose of notifications

--- a/include/ProxyWifi/ProxyWifiService.hpp
+++ b/include/ProxyWifi/ProxyWifiService.hpp
@@ -99,13 +99,23 @@ enum class OperationType
 class ProxyWifiObserver
 {
 public:
+    struct ConnectCompleteArgs {
+        GUID interfaceGuid;
+        DOT11_SSID ssid;
+        DOT11_AUTH_ALGORITHM authAlgo;
+    };
+    struct DisconnectCompleteArgs {
+        GUID interfaceGuid;
+        DOT11_SSID ssid;
+    };
+
     /// @brief An host WiFi interface connected to a network
-    virtual void OnHostConnection(const GUID& interfaceGuid, const DOT11_SSID& ssid, DOT11_AUTH_ALGORITHM authAlgo) noexcept
+    virtual void OnHostConnection(const ConnectCompleteArgs& connectionInfo) noexcept
     {
     }
 
     /// @brief An host WiFi interface disconnected from a network
-    virtual void OnHostDisconnection(const GUID& interfaceGuid, const DOT11_SSID& ssid) noexcept
+    virtual void OnHostDisconnection(const DisconnectCompleteArgs& disconnectionInfo) noexcept
     {
     }
 
@@ -120,7 +130,7 @@ public:
     /// If `type == OperationType::HostMirroring`, an host inteface was already connected to the network, otherwise, one has been be connected
     /// The response won't be sent to the guest until this callback returns
     virtual void OnGuestConnectionCompletion(
-        OperationType type, OperationStatus status, const GUID& interfaceGuid, const DOT11_SSID& ssid, DOT11_AUTH_ALGORITHM authAlgo) noexcept
+        OperationType type, OperationStatus status, const ConnectCompleteArgs& connectionInfo) noexcept
     {
     }
 
@@ -134,7 +144,7 @@ public:
     /// @brief A guest disconnection request was processed
     /// If `type == OperationType::HostMirroring`, this was a no-op for the host, otherwise, a matching host interface has been disconnected
     /// The response won't be sent to the guest until this callback returns
-    virtual void OnGuestDisconnectionCompletion(OperationType type, OperationStatus status, const GUID& interfaceGuid, const DOT11_SSID& ssid) noexcept
+    virtual void OnGuestDisconnectionCompletion(OperationType type, OperationStatus status, const DisconnectCompleteArgs& disconnectionInfo) noexcept
     {
     }
 

--- a/lib/OperationHandler.cpp
+++ b/lib/OperationHandler.cpp
@@ -215,10 +215,10 @@ void OperationHandler::AddInterface(const std::function<std::unique_ptr<IWlanInt
     m_serializedRunner.Run([this, wlanInterfaceBuilder] {
         auto wlanInterface = wlanInterfaceBuilder();
         const auto& newGuid = wlanInterface->GetGuid();
-        auto foundIt =
-            std::find_if(m_wlanInterfaces.begin(), m_wlanInterfaces.end(), [&](const auto& i) { return i->GetGuid() == newGuid; });
+        auto alreadyPresent =
+            std::any_of(m_wlanInterfaces.begin(), m_wlanInterfaces.end(), [&](const auto& i) { return i->GetGuid() == newGuid; });
 
-        if (foundIt != m_wlanInterfaces.end())
+        if (alreadyPresent)
         {
             // The interface is already present, nothing to do
             Log::Debug(L"Interfaces %ws already present", GuidToString(wlanInterface->GetGuid()).c_str());

--- a/lib/OperationHandler.cpp
+++ b/lib/OperationHandler.cpp
@@ -90,7 +90,7 @@ void OperationHandler::OnGuestConnectionCompletion(OperationType type, Operation
 
         if (m_clientObserver)
         {
-            m_clientObserver->OnGuestConnectionCompletion(type, status, interfaceGuid, ssid, authAlgo);
+            m_clientObserver->OnGuestConnectionCompletion(type, status, {interfaceGuid, ssid, authAlgo});
         }
     });
 }
@@ -122,7 +122,7 @@ void OperationHandler::OnGuestDisconnectionCompletion(OperationType type, Operat
 
         if (m_clientObserver)
         {
-            m_clientObserver->OnGuestDisconnectionCompletion(type, status, interfaceGuid, ssid);
+            m_clientObserver->OnGuestDisconnectionCompletion(type, status, {interfaceGuid, ssid});
         }
     });
 }
@@ -154,15 +154,15 @@ void OperationHandler::OnGuestScanCompletion(OperationStatus status) noexcept
 void OperationHandler::OnHostConnection(const GUID& interfaceGuid, const Ssid& ssid, DOT11_AUTH_ALGORITHM authAlgo)
 {
     // Always notify the client on a new host connection
-    m_clientNotificationQueue.Run([this, interfaceGuid, ssid, authAlgo] {
+    m_clientNotificationQueue.Run([this, args = ProxyWifiObserver::ConnectCompleteArgs{interfaceGuid, ssid, authAlgo}] {
         Log::Info(
             L"Notifying the client of a host connection. Interface: %ws, Ssid: %ws, Auth Algo: %ws",
-            GuidToString(interfaceGuid).c_str(),
-            SsidToLogString(ssid.value()).c_str(),
-            Wlansvc::AuthAlgoToString(authAlgo).c_str());
+            GuidToString(args.interfaceGuid).c_str(),
+            SsidToLogString({args.ssid.ucSSID, args.ssid.uSSIDLength}).c_str(),
+            Wlansvc::AuthAlgoToString(args.authAlgo).c_str());
         if (m_clientObserver)
         {
-            m_clientObserver->OnHostConnection(interfaceGuid, ssid, authAlgo);
+            m_clientObserver->OnHostConnection(args);
         }
     });
 }
@@ -170,15 +170,15 @@ void OperationHandler::OnHostConnection(const GUID& interfaceGuid, const Ssid& s
 void OperationHandler::OnHostDisconnection(const GUID& interfaceGuid, const Ssid& ssid)
 {
     // Notify the client first
-    m_clientNotificationQueue.Run([this, interfaceGuid, ssid] {
+    m_clientNotificationQueue.Run([this, args = ProxyWifiObserver::DisconnectCompleteArgs{interfaceGuid, ssid}] {
         Log::Info(
             L"Notifying the client of a host disconnection. Interface: %ws, Ssid: %ws",
-            GuidToString(interfaceGuid).c_str(),
-            SsidToLogString(ssid.value()).c_str());
+            GuidToString(args.interfaceGuid).c_str(),
+            SsidToLogString({args.ssid.ucSSID, args.ssid.uSSIDLength}).c_str());
 
         if (m_clientObserver)
         {
-            m_clientObserver->OnHostDisconnection(interfaceGuid, ssid);
+            m_clientObserver->OnHostDisconnection(args);
         }
     });
 

--- a/lib/OperationHandler.cpp
+++ b/lib/OperationHandler.cpp
@@ -13,33 +13,31 @@ namespace ProxyWifi {
 
 namespace {
 
-const wchar_t* EventSourceToString(EventSource e)
-{
-    switch (e)
+    const wchar_t* ToString(OperationStatus s)
     {
-    case EventSource::Host:
-        return L"Host";
-    case EventSource::Guest:
-        return L"Guest";
-    default:
-        return L"Unknown source";
+        switch (s)
+        {
+        case OperationStatus::Succeeded:
+            return L"Succeeded";
+        case OperationStatus::Failed:
+            return L"Failed";
+        default:
+            return L"Unknown status";
+        }
     }
-}
 
-const wchar_t* GuestConnectStatusToString(GuestConnectStatus s)
-{
-    switch (s)
+    const wchar_t* ToString(OperationType t)
     {
-    case GuestConnectStatus::Starting:
-        return L"Started";
-    case GuestConnectStatus::Succeeded:
-        return L"Succeeded";
-    case GuestConnectStatus::Failed:
-        return L"Failed";
-    default:
-        return L"Unknown source";
+        switch (t)
+        {
+        case OperationType::GuestDirected:
+            return L"GuestDirected";
+        case OperationType::HostMirroring:
+            return L"HostMirroring";
+        default:
+            return L"Unknown type";
+        }
     }
-}
 
 } // namespace
 
@@ -64,56 +62,91 @@ void OperationHandler::SendGuestNotification(std::variant<DisconnectNotif, Signa
     }
 }
 
-void OperationHandler::NotifyConnectionToClientSerialized(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network, DOT11_AUTH_ALGORITHM authAlgo)
+void OperationHandler::OnGuestConnectionRequest(OperationType type, const Ssid& ssid) noexcept
 {
-    Log::Info(
-        L"Notifying a connection to client. Source: %ws, Interface: %ws, Ssid: %ws, Auth Algo: %ws",
-        EventSourceToString(source),
-        GuidToString(interfaceGuid).c_str(),
-        SsidToLogString(gsl::span{network.ucSSID, network.uSSIDLength}).c_str(),
-        Wlansvc::AuthAlgoToString(authAlgo).c_str());
+    m_clientNotificationQueue.RunAndWait([&] {
+        Log::Info(
+            L"Notifying the client of a guest connection request. Type: %ws, Ssid: %ws",
+            ToString(type),
+            SsidToLogString(ssid.value()).c_str());
 
-    if (m_clientCallbacks.OnConnection)
-    {
-        m_clientCallbacks.OnConnection(source, {interfaceGuid, network, authAlgo});
-    }
-}
-
-void OperationHandler::NotifyDisconnectionToClientSerialized(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network)
-{
-    Log::Info(
-        L"Notifying a disconnection to client. Source: %ws, Interface: %ws, Ssid: %ws",
-        EventSourceToString(source),
-        GuidToString(interfaceGuid).c_str(),
-        SsidToLogString(gsl::span{network.ucSSID, network.uSSIDLength}).c_str());
-
-    if (m_clientCallbacks.OnDisconnection)
-    {
-        m_clientCallbacks.OnDisconnection(source, {interfaceGuid, network});
-    }
-}
-
-void OperationHandler::NotifyConnectionToClient(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network, DOT11_AUTH_ALGORITHM authAlgo)
-{
-    m_clientNotificationQueue.RunAndWait([this, source, interfaceGuid, network, authAlgo] {
-        NotifyConnectionToClientSerialized(source, interfaceGuid, network, authAlgo);
+        if (m_clientObserver)
+        {
+            m_clientObserver->OnGuestConnectionRequest(type, ssid);
+        }
     });
 }
 
-void OperationHandler::NotifyDisconnectionToClient(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network)
+void OperationHandler::OnGuestConnectionCompletion(OperationType type, OperationStatus status, const GUID& interfaceGuid, const Ssid& ssid, DOT11_AUTH_ALGORITHM authAlgo) noexcept
 {
-    m_clientNotificationQueue.RunAndWait(
-        [this, source, interfaceGuid, network] { NotifyDisconnectionToClientSerialized(source, interfaceGuid, network); });
+    m_clientNotificationQueue.RunAndWait([&] {
+        Log::Info(
+            L"Notifying the client of a guest connection completion. Type: %ws, Status: %ws, Interface: %ws, Ssid: %ws, AuthAlgo: %ws",
+            ToString(type),
+            ToString(status),
+            GuidToString(interfaceGuid).c_str(),
+            SsidToLogString(ssid.value()).c_str(),
+            Wlansvc::AuthAlgoToString(authAlgo).c_str());
+
+        if (m_clientObserver)
+        {
+            m_clientObserver->OnGuestConnectionCompletion(type, status, interfaceGuid, ssid, authAlgo);
+        }
+    });
 }
 
-void OperationHandler::NotifyGuestConnectRequestProgress(GuestConnectStatus status)
+void OperationHandler::OnGuestDisconnectionRequest(OperationType type, const Ssid& ssid) noexcept
 {
-    m_clientNotificationQueue.RunAndWait([this, status] {
-        Log::Info(L"Notifying guest directed connection progress to the client. Status: %ws", GuestConnectStatusToString(status));
+    m_clientNotificationQueue.RunAndWait([&] {
+        Log::Info(
+            L"Notifying the client of a guest disconnection request. Type: %ws, Ssid: %ws",
+            ToString(type),
+            SsidToLogString(ssid.value()).c_str());
 
-        if (m_clientCallbacks.OnGuestConnectRequestProgress)
+        if (m_clientObserver)
         {
-            m_clientCallbacks.OnGuestConnectRequestProgress(status);
+            m_clientObserver->OnGuestDisconnectionRequest(type, ssid);
+        }
+    });
+}
+
+void OperationHandler::OnGuestDisconnectionCompletion(OperationType type, OperationStatus status, const GUID& interfaceGuid, const Ssid& ssid) noexcept
+{
+    m_clientNotificationQueue.RunAndWait([&] {
+        Log::Info(
+            L"Notifying the client of a guest disconnection completion. Type: %ws, Status: %ws, Interface: %ws, Ssid: %ws",
+            ToString(type),
+            ToString(status),
+            GuidToString(interfaceGuid).c_str(),
+            SsidToLogString(ssid.value()).c_str());
+
+        if (m_clientObserver)
+        {
+            m_clientObserver->OnGuestDisconnectionCompletion(type, status, interfaceGuid, ssid);
+        }
+    });
+}
+
+void OperationHandler::OnGuestScanRequest() noexcept
+{
+    m_clientNotificationQueue.RunAndWait([&] {
+        Log::Info(L"Notifying the client of a guest scan request");
+
+        if (m_clientObserver)
+        {
+            m_clientObserver->OnGuestScanRequest();
+        }
+    });
+}
+
+void OperationHandler::OnGuestScanCompletion(OperationStatus status) noexcept
+{
+    m_clientNotificationQueue.RunAndWait([&] {
+        Log::Info(L"Notifying the client of a guest scan completion. Status: %ws", ToString(status));
+
+        if (m_clientObserver)
+        {
+            m_clientObserver->OnGuestScanCompletion(status);
         }
     });
 }
@@ -122,15 +155,32 @@ void OperationHandler::OnHostConnection(const GUID& interfaceGuid, const Ssid& s
 {
     // Always notify the client on a new host connection
     m_clientNotificationQueue.Run([this, interfaceGuid, ssid, authAlgo] {
-        NotifyConnectionToClientSerialized(EventSource::Host, interfaceGuid, ssid, authAlgo);
+        Log::Info(
+            L"Notifying the client of a host connection. Interface: %ws, Ssid: %ws, Auth Algo: %ws",
+            GuidToString(interfaceGuid).c_str(),
+            SsidToLogString(ssid.value()).c_str(),
+            Wlansvc::AuthAlgoToString(authAlgo).c_str());
+        if (m_clientObserver)
+        {
+            m_clientObserver->OnHostConnection(interfaceGuid, ssid, authAlgo);
+        }
     });
 }
 
 void OperationHandler::OnHostDisconnection(const GUID& interfaceGuid, const Ssid& ssid)
 {
     // Notify the client first
-    m_clientNotificationQueue.Run(
-        [this, interfaceGuid, ssid] { NotifyDisconnectionToClientSerialized(EventSource::Host, interfaceGuid, ssid); });
+    m_clientNotificationQueue.Run([this, interfaceGuid, ssid] {
+        Log::Info(
+            L"Notifying the client of a host disconnection. Interface: %ws, Ssid: %ws",
+            GuidToString(interfaceGuid).c_str(),
+            SsidToLogString(ssid.value()).c_str());
+
+        if (m_clientObserver)
+        {
+            m_clientObserver->OnHostDisconnection(interfaceGuid, ssid);
+        }
+    });
 
     // If this is a spontaneous disconnection from the host on the interface currently used by the guest,
     // send a disconnect notification to the guest and mark it as disconnected
@@ -138,13 +188,13 @@ void OperationHandler::OnHostDisconnection(const GUID& interfaceGuid, const Ssid
     // TODO guhetier: Remove this completely or keep it behind a flag for having it in the public lib?
 
     // m_serializedRunner.Run([this, interfaceGuid] {
-        // if (m_guestConnection && interfaceGuid == m_guestConnection->interfaceGuid)
-        // {
-        //     m_guestConnection.reset();
+    // if (m_guestConnection && interfaceGuid == m_guestConnection->interfaceGuid)
+    // {
+    //     m_guestConnection.reset();
 
-        //     Log::Trace(L"Sending Disconnection notification to the guest");
-        //     SendGuestNotification(DisconnectNotif{m_sessionId});
-        // }
+    //     Log::Trace(L"Sending Disconnection notification to the guest");
+    //     SendGuestNotification(DisconnectNotif{m_sessionId});
+    // }
     // });
 }
 
@@ -160,22 +210,13 @@ void OperationHandler::OnHostSignalQualityChange(const GUID& interfaceGuid, unsi
     });
 }
 
-std::vector<WifiNetworkInfo> OperationHandler::GetUserBss()
-{
-    if (m_clientCallbacks.ProvideFakeNetworks)
-    {
-        return m_clientCallbacks.ProvideFakeNetworks();
-    }
-    return {};
-}
-
 void OperationHandler::AddInterface(const std::function<std::unique_ptr<IWlanInterface>()>& wlanInterfaceBuilder)
 {
     m_serializedRunner.Run([this, wlanInterfaceBuilder] {
         auto wlanInterface = wlanInterfaceBuilder();
         const auto& newGuid = wlanInterface->GetGuid();
-        auto foundIt = std::find_if(
-            m_wlanInterfaces.begin(), m_wlanInterfaces.end(), [&](const auto& i) { return i->GetGuid() == newGuid; });
+        auto foundIt =
+            std::find_if(m_wlanInterfaces.begin(), m_wlanInterfaces.end(), [&](const auto& i) { return i->GetGuid() == newGuid; });
 
         if (foundIt != m_wlanInterfaces.end())
         {
@@ -222,15 +263,16 @@ ConnectResponse OperationHandler::HandleConnectRequestSerialized(const ConnectRe
             const auto connectedIntfGuid = wlanIntf->GetGuid();
             m_guestConnection = {ConnectionType::Mirrored, connectedIntfGuid, ssid};
 
-            // Notify clients the guest is mirroring a connection
-            NotifyConnectionToClient(EventSource::Guest, connectedIntfGuid, ssid, networkInfo->auth);
+            Log::Info(L"Successfully mirrored the connection on interface %ws. Notifying clients.", GuidToString(connectedIntfGuid).c_str());
+            OnGuestConnectionRequest(OperationType::HostMirroring, ssid);
+            OnGuestConnectionCompletion(OperationType::HostMirroring, OperationStatus::Succeeded, connectedIntfGuid, ssid, networkInfo->auth);
 
             return ConnectResponse{WlanStatus::Success, networkInfo->bssid, ++m_sessionId};
         }
     }
 
-    // At this point, an host interface will be connected: signal the start of the processus to lib clients
-    NotifyGuestConnectRequestProgress(GuestConnectStatus::Starting);
+    // At this point, an host interface will be connected. Notify the client of a guest direct connection
+    OnGuestConnectionRequest(OperationType::GuestDirected, ssid);
 
     try
     {
@@ -285,23 +327,22 @@ ConnectResponse OperationHandler::HandleConnectRequestSerialized(const ConnectRe
                 m_guestConnection = {ConnectionType::GuestDirected, connectedIntfGuid, ssid};
 
                 Log::Info(L"Successfully connected on interface %ws. Notifying clients.", GuidToString(connectedIntfGuid).c_str());
-                NotifyConnectionToClient(EventSource::Guest, connectedIntfGuid, ssid, networkInfo.auth);
-                NotifyGuestConnectRequestProgress(GuestConnectStatus::Succeeded);
+                OnGuestConnectionCompletion(OperationType::GuestDirected, OperationStatus::Succeeded, connectedIntfGuid, ssid, networkInfo.auth);
 
                 return ConnectResponse{connectionResult, networkInfo.bssid, ++m_sessionId};
             }
         }
 
         Log::Info(L"All interfaces failed to connect. Answering with a failure.");
-        NotifyGuestConnectRequestProgress(GuestConnectStatus::Failed);
+        OnGuestConnectionCompletion(OperationType::GuestDirected, OperationStatus::Failed, {}, ssid, {});
         return ConnectResponse{WlanStatus::UnspecifiedFailure, Bssid{}, ++m_sessionId};
     }
     catch (...)
     {
         LOG_CAUGHT_EXCEPTION();
         // Need send the connect request completion notification
-        NotifyGuestConnectRequestProgress(GuestConnectStatus::Failed);
-        throw;
+        OnGuestConnectionCompletion(OperationType::GuestDirected, OperationStatus::Failed, {}, ssid, {});
+        return ConnectResponse{WlanStatus::UnspecifiedFailure, Bssid{}, ++m_sessionId};
     }
 }
 
@@ -326,22 +367,30 @@ DisconnectResponse OperationHandler::HandleDisconnectRequestSerialized(const Dis
         return DisconnectResponse{};
     }
 
-    // Operations to do on every exit paths (whether the host must disconnect or not)
-    auto completeDisconnection = [&] {
-
-        const auto guestConnectInfo = m_guestConnection;
-        m_guestConnection.reset();
-
-        NotifyDisconnectionToClient(EventSource::Guest, guestConnectInfo->interfaceGuid, guestConnectInfo->ssid);
-        return DisconnectResponse{};
-    };
-
     if (m_guestConnection->type != ConnectionType::GuestDirected)
     {
         // Don't disconnect the host interface, simply answer to the guest
         Log::Info(L"Keeping the host connected since the connection wasn't guest directed.");
-        return completeDisconnection();
+        OnGuestDisconnectionRequest(OperationType::HostMirroring, m_guestConnection->ssid);
+
+        const auto guestConnectInfo = m_guestConnection;
+        m_guestConnection.reset();
+
+        OnGuestDisconnectionCompletion(OperationType::HostMirroring, OperationStatus::Succeeded, guestConnectInfo->interfaceGuid, guestConnectInfo->ssid);
+        return DisconnectResponse();
     }
+
+
+    // At this point, an host interface will be disconnected. Notify the client (make sure it is notified of the completion on each path)
+    OnGuestDisconnectionRequest(OperationType::GuestDirected, m_guestConnection->ssid);
+
+    auto completeDisconnection = [&] {
+        const auto guestConnectInfo = m_guestConnection;
+        m_guestConnection.reset();
+
+        OnGuestDisconnectionCompletion(OperationType::GuestDirected, OperationStatus::Succeeded, guestConnectInfo->interfaceGuid, guestConnectInfo->ssid);
+        return DisconnectResponse{};
+    };
 
     auto interfaceToDisconnect = std::find_if(m_wlanInterfaces.begin(), m_wlanInterfaces.end(), [&](const auto& i) {
         return m_guestConnection->interfaceGuid == i->GetGuid();
@@ -379,6 +428,9 @@ DisconnectResponse OperationHandler::HandleDisconnectRequest(const DisconnectReq
 
 ScanResponse OperationHandler::HandleScanRequestSerialized(const ScanRequest& scanRequest)
 {
+    // Notify the client that the guest is scanning
+    OnGuestScanRequest();
+
     auto requestedSsid =
         scanRequest->ssid_len > 0 ? std::make_optional<const Ssid>(gsl::span{scanRequest->ssid, scanRequest->ssid_len}) : std::nullopt;
 
@@ -398,22 +450,26 @@ ScanResponse OperationHandler::HandleScanRequestSerialized(const ScanRequest& sc
     const auto timeout = std::chrono::steady_clock::now() + std::chrono::seconds(10);
     for (auto& scanFuture : futureScanResults)
     {
-        std::vector<ScannedBss> scanResults;
-        if (scanFuture.wait_until(timeout) != std::future_status::ready)
-        {
-            LOG_WIN32_MSG(ERROR_TIMEOUT, "Scan timed out.");
-        }
-        else
-        {
-            scanResults = scanFuture.get();
-        }
+        try {
+            std::vector<ScannedBss> scanResults;
+            if (scanFuture.wait_until(timeout) != std::future_status::ready)
+            {
+                LOG_WIN32_MSG(ERROR_TIMEOUT, "Scan timed out.");
+            }
+            else
+            {
+                scanResults = scanFuture.get();
+            }
 
-        for (const auto& bss : scanResults)
-        {
-            scanResponse.AddBss(bss);
+            for (const auto& bss : scanResults)
+            {
+                scanResponse.AddBss(bss);
+            }
         }
+        CATCH_LOG_MSG("Failed to retreive an interface scan results")
     }
 
+    OnGuestScanCompletion(OperationStatus::Succeeded);
     return scanResponse.Build();
 }
 

--- a/lib/OperationHandler.cpp
+++ b/lib/OperationHandler.cpp
@@ -72,7 +72,7 @@ void OperationHandler::OnGuestConnectionRequest(OperationType type, const Ssid& 
 
         if (m_clientObserver)
         {
-            m_clientObserver->OnGuestConnectionRequest(type, ssid);
+            m_clientObserver->OnGuestConnectionRequest(type, {ssid});
         }
     });
 }
@@ -105,7 +105,7 @@ void OperationHandler::OnGuestDisconnectionRequest(OperationType type, const Ssi
 
         if (m_clientObserver)
         {
-            m_clientObserver->OnGuestDisconnectionRequest(type, ssid);
+            m_clientObserver->OnGuestDisconnectionRequest(type, {ssid});
         }
     });
 }

--- a/lib/OperationHandler.cpp
+++ b/lib/OperationHandler.cpp
@@ -70,9 +70,9 @@ void OperationHandler::OnGuestConnectionRequest(OperationType type, const Ssid& 
             ToString(type),
             SsidToLogString(ssid.value()).c_str());
 
-        if (m_clientObserver)
+        if (m_pClientObserver)
         {
-            m_clientObserver->OnGuestConnectionRequest(type, {ssid});
+            m_pClientObserver->OnGuestConnectionRequest(type, {ssid});
         }
     });
 }
@@ -88,9 +88,9 @@ void OperationHandler::OnGuestConnectionCompletion(OperationType type, Operation
             SsidToLogString(ssid.value()).c_str(),
             Wlansvc::AuthAlgoToString(authAlgo).c_str());
 
-        if (m_clientObserver)
+        if (m_pClientObserver)
         {
-            m_clientObserver->OnGuestConnectionCompletion(type, status, {interfaceGuid, ssid, authAlgo});
+            m_pClientObserver->OnGuestConnectionCompletion(type, status, {interfaceGuid, ssid, authAlgo});
         }
     });
 }
@@ -103,9 +103,9 @@ void OperationHandler::OnGuestDisconnectionRequest(OperationType type, const Ssi
             ToString(type),
             SsidToLogString(ssid.value()).c_str());
 
-        if (m_clientObserver)
+        if (m_pClientObserver)
         {
-            m_clientObserver->OnGuestDisconnectionRequest(type, {ssid});
+            m_pClientObserver->OnGuestDisconnectionRequest(type, {ssid});
         }
     });
 }
@@ -120,9 +120,9 @@ void OperationHandler::OnGuestDisconnectionCompletion(OperationType type, Operat
             GuidToString(interfaceGuid).c_str(),
             SsidToLogString(ssid.value()).c_str());
 
-        if (m_clientObserver)
+        if (m_pClientObserver)
         {
-            m_clientObserver->OnGuestDisconnectionCompletion(type, status, {interfaceGuid, ssid});
+            m_pClientObserver->OnGuestDisconnectionCompletion(type, status, {interfaceGuid, ssid});
         }
     });
 }
@@ -132,9 +132,9 @@ void OperationHandler::OnGuestScanRequest() noexcept
     m_clientNotificationQueue.RunAndWait([&] {
         Log::Info(L"Notifying the client of a guest scan request");
 
-        if (m_clientObserver)
+        if (m_pClientObserver)
         {
-            m_clientObserver->OnGuestScanRequest();
+            m_pClientObserver->OnGuestScanRequest();
         }
     });
 }
@@ -144,9 +144,9 @@ void OperationHandler::OnGuestScanCompletion(OperationStatus status) noexcept
     m_clientNotificationQueue.RunAndWait([&] {
         Log::Info(L"Notifying the client of a guest scan completion. Status: %ws", ToString(status));
 
-        if (m_clientObserver)
+        if (m_pClientObserver)
         {
-            m_clientObserver->OnGuestScanCompletion(status);
+            m_pClientObserver->OnGuestScanCompletion(status);
         }
     });
 }
@@ -160,9 +160,9 @@ void OperationHandler::OnHostConnection(const GUID& interfaceGuid, const Ssid& s
             GuidToString(args.interfaceGuid).c_str(),
             SsidToLogString({args.ssid.ucSSID, args.ssid.uSSIDLength}).c_str(),
             Wlansvc::AuthAlgoToString(args.authAlgo).c_str());
-        if (m_clientObserver)
+        if (m_pClientObserver)
         {
-            m_clientObserver->OnHostConnection(args);
+            m_pClientObserver->OnHostConnection(args);
         }
     });
 }
@@ -176,9 +176,9 @@ void OperationHandler::OnHostDisconnection(const GUID& interfaceGuid, const Ssid
             GuidToString(args.interfaceGuid).c_str(),
             SsidToLogString({args.ssid.ucSSID, args.ssid.uSSIDLength}).c_str());
 
-        if (m_clientObserver)
+        if (m_pClientObserver)
         {
-            m_clientObserver->OnHostDisconnection(args);
+            m_pClientObserver->OnHostDisconnection(args);
         }
     });
 

--- a/lib/OperationHandler.cpp
+++ b/lib/OperationHandler.cpp
@@ -450,7 +450,8 @@ ScanResponse OperationHandler::HandleScanRequestSerialized(const ScanRequest& sc
     const auto timeout = std::chrono::steady_clock::now() + std::chrono::seconds(10);
     for (auto& scanFuture : futureScanResults)
     {
-        try {
+        try
+        {
             std::vector<ScannedBss> scanResults;
             if (scanFuture.wait_until(timeout) != std::future_status::ready)
             {

--- a/lib/OperationHandler.hpp
+++ b/lib/OperationHandler.hpp
@@ -24,8 +24,8 @@ namespace ProxyWifi {
 class OperationHandler: private INotificationHandler
 {
 public:
-    OperationHandler(ProxyWifiCallbacks callbacks, std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces)
-        : m_clientCallbacks{std::move(callbacks)}, m_wlanInterfaces{std::move(wlanInterfaces)}
+    OperationHandler(std::shared_ptr<ProxyWifiObserver> observer, std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces)
+        : m_clientObserver{std::move(observer)}, m_wlanInterfaces{std::move(wlanInterfaces)}
     {
         for (auto& wlanIntf: m_wlanInterfaces)
         {
@@ -69,8 +69,6 @@ protected:
     /// @brief Must be called by the interfaces when the signal quality changes
     void OnHostSignalQualityChange(const GUID& interfaceGuid, unsigned long signalQuality) override;
 
-    std::vector<WifiNetworkInfo> GetUserBss();
-
 private:
 
     // These functions do the actual handling of the request from a seriliazed work queue
@@ -81,25 +79,19 @@ private:
     /// @brief Send a notification to the guest
     void SendGuestNotification(std::variant<DisconnectNotif, SignalQualityNotif> notif);
 
-    void NotifyConnectionToClientSerialized(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network, DOT11_AUTH_ALGORITHM authAlgo);
-    void NotifyDisconnectionToClientSerialized(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network);
-
-    /// @brief Notify the lib user that the host/guest connected
-    void NotifyConnectionToClient(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network, DOT11_AUTH_ALGORITHM authAlgo);
-
-    /// @brief Notifiy the lib user that the host/guest disconnected
-    void NotifyDisconnectionToClient(EventSource source, const GUID& interfaceGuid, const DOT11_SSID& network);
-
-    /// @brief Notifiy the lib user that of the current status of a guest driven connection
-    /// This must be called when the connect request will cause a host interface to actually connect.
-    /// It must indicate the start of the process and the final result (success or failure)
-    void NotifyGuestConnectRequestProgress(GuestConnectStatus status);
+    /// @brief Notify the guest of guest operation request and completion
+    void OnGuestConnectionRequest(OperationType type, const Ssid& ssid) noexcept;
+    void OnGuestConnectionCompletion(OperationType type, OperationStatus status, const GUID& interfaceGuid, const Ssid& ssid, DOT11_AUTH_ALGORITHM authAlgo) noexcept;
+    void OnGuestDisconnectionRequest(OperationType type, const Ssid& ssid) noexcept;
+    void OnGuestDisconnectionCompletion(OperationType type, OperationStatus status, const GUID& interfaceGuid, const Ssid& ssid) noexcept;
+    void OnGuestScanRequest() noexcept;
+    void OnGuestScanCompletion(OperationStatus status) noexcept;
 
     std::shared_mutex m_notificationLock;
     GuestNotificationCallback m_notificationCallback;
 
-    // TODO guhetier: Try to get only the two necessary callback there? The last one is only needed for the fake interface
-    ProxyWifiCallbacks m_clientCallbacks;
+    /// @brief Client provided object to notify client of various events
+    std::shared_ptr<ProxyWifiObserver> m_clientObserver;
 
     enum class ConnectionType
     {
@@ -130,7 +122,9 @@ private:
 
     std::vector<std::unique_ptr<IWlanInterface>> m_wlanInterfaces;
 
+    /// @brief Serialized workqueue processing guest requests and guest notifications
     SerializedWorkRunner m_serializedRunner;
+    /// @brief Serialized workqueue sending client notifications
     SerializedWorkRunner m_clientNotificationQueue;
 };
 

--- a/lib/OperationHandler.hpp
+++ b/lib/OperationHandler.hpp
@@ -24,8 +24,8 @@ namespace ProxyWifi {
 class OperationHandler: private INotificationHandler
 {
 public:
-    OperationHandler(std::shared_ptr<ProxyWifiObserver> observer, std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces)
-        : m_clientObserver{std::move(observer)}, m_wlanInterfaces{std::move(wlanInterfaces)}
+    OperationHandler(ProxyWifiObserver* pObserver, std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces)
+        : m_pClientObserver{pObserver}, m_wlanInterfaces{std::move(wlanInterfaces)}
     {
         for (auto& wlanIntf: m_wlanInterfaces)
         {
@@ -91,7 +91,7 @@ private:
     GuestNotificationCallback m_notificationCallback;
 
     /// @brief Client provided object to notify client of various events
-    std::shared_ptr<ProxyWifiObserver> m_clientObserver;
+    ProxyWifiObserver* m_pClientObserver = nullptr;
 
     enum class ConnectionType
     {

--- a/lib/OperationHandlerBuilder.hpp
+++ b/lib/OperationHandlerBuilder.hpp
@@ -15,7 +15,7 @@
 
 namespace ProxyWifi {
 
-inline std::unique_ptr<OperationHandler> MakeWlansvcOperationHandler(std::shared_ptr<Wlansvc::WlanApiWrapper> wlansvc, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer)
+inline std::unique_ptr<OperationHandler> MakeWlansvcOperationHandler(std::shared_ptr<Wlansvc::WlanApiWrapper> wlansvc, FakeNetworkProvider fakeNetworkCallback, ProxyWifiObserver* pObserver)
 {
     std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces;
     // Add an interface for user defined networks, if a callback is provided. Must be first to take priority over the other interfaces
@@ -43,17 +43,17 @@ inline std::unique_ptr<OperationHandler> MakeWlansvcOperationHandler(std::shared
         }
 
         Log::Info(L"Creating a Wlansvc enabled opeartion handler");
-        return std::make_unique<WlansvcOperationHandler>(std::move(observer), std::move(wlanInterfaces), wlansvc);
+        return std::make_unique<WlansvcOperationHandler>(pObserver, std::move(wlanInterfaces), wlansvc);
     }
     else
     {
         // Without wlansvc, we can't handle interfaces arrival/departures anyway, so an `OperationHandler` is enough
         Log::Info(L"Creating a client network only operation handler");
-        return std::make_unique<OperationHandler>(std::move(observer), std::move(wlanInterfaces));
+        return std::make_unique<OperationHandler>(pObserver, std::move(wlanInterfaces));
     }
 }
 
-inline std::unique_ptr<OperationHandler> MakeManualTestOperationHandler(FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer)
+inline std::unique_ptr<OperationHandler> MakeManualTestOperationHandler(FakeNetworkProvider fakeNetworkCallback, ProxyWifiObserver* pObserver)
 {
     std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces;
     // Add an interface for user defined networks if a callback is provided
@@ -66,7 +66,7 @@ inline std::unique_ptr<OperationHandler> MakeManualTestOperationHandler(FakeNetw
     wlanInterfaces.push_back(
         std::make_unique<TestWlanInterface>(GUID{0xc386c570, 0xf576, 0x4f7e, {0xbf, 0x19, 0xd2, 0x32, 0x3a, 0xf8, 0xdd, 0x19}}));
 
-    return std::make_unique<OperationHandler>(std::move(observer), std::move(wlanInterfaces));
+    return std::make_unique<OperationHandler>(pObserver, std::move(wlanInterfaces));
 }
 
 } // namespace ProxyWifi

--- a/lib/OperationHandlerBuilder.hpp
+++ b/lib/OperationHandlerBuilder.hpp
@@ -15,12 +15,15 @@
 
 namespace ProxyWifi {
 
-inline std::unique_ptr<OperationHandler> MakeWlansvcOperationHandler(std::shared_ptr<Wlansvc::WlanApiWrapper> wlansvc, ProxyWifiCallbacks callbacks)
+inline std::unique_ptr<OperationHandler> MakeWlansvcOperationHandler(std::shared_ptr<Wlansvc::WlanApiWrapper> wlansvc, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer)
 {
     std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces;
-    // Add an interface for user defined networks. Must be first to take priority over the other interfaces
-    wlanInterfaces.push_back(std::make_unique<ClientWlanInterface>(FakeInterfaceGuid, std::move(callbacks.ProvideFakeNetworks)));
-    callbacks.ProvideFakeNetworks = {};
+    // Add an interface for user defined networks, if a callback is provided. Must be first to take priority over the other interfaces
+    if (fakeNetworkCallback)
+    {
+        Log::Info(L"Adding client interface %ws", GuidToString(FakeInterfaceGuid).c_str());
+        wlanInterfaces.push_back(std::make_unique<ClientWlanInterface>(FakeInterfaceGuid, std::move(fakeNetworkCallback)));
+    }
 
     // Add the real wlan interfaces
     if (wlansvc)
@@ -38,26 +41,32 @@ inline std::unique_ptr<OperationHandler> MakeWlansvcOperationHandler(std::shared
                 LOG_CAUGHT_EXCEPTION_MSG("Failed to initialize a wlansvc interface. Skipping it.");
             }
         }
-        return std::make_unique<WlansvcOperationHandler>(std::move(callbacks), std::move(wlanInterfaces), wlansvc);
+
+        Log::Info(L"Creating a Wlansvc enabled opeartion handler");
+        return std::make_unique<WlansvcOperationHandler>(std::move(observer), std::move(wlanInterfaces), wlansvc);
     }
     else
     {
         // Without wlansvc, we can't handle interfaces arrival/departures anyway, so an `OperationHandler` is enough
-        return std::make_unique<OperationHandler>(std::move(callbacks), std::move(wlanInterfaces));
+        Log::Info(L"Creating a client network only operation handler");
+        return std::make_unique<OperationHandler>(std::move(observer), std::move(wlanInterfaces));
     }
 }
 
-inline std::unique_ptr<OperationHandler> MakeManualTestOperationHandler(ProxyWifiCallbacks callbacks)
+inline std::unique_ptr<OperationHandler> MakeManualTestOperationHandler(FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer)
 {
     std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces;
-    // Add an interface for user defined networks
-    wlanInterfaces.push_back(std::make_unique<ClientWlanInterface>(FakeInterfaceGuid, std::move(callbacks.ProvideFakeNetworks)));
-    callbacks.ProvideFakeNetworks = {};
+    // Add an interface for user defined networks if a callback is provided
+    if (fakeNetworkCallback)
+    {
+        wlanInterfaces.push_back(std::make_unique<ClientWlanInterface>(FakeInterfaceGuid, std::move(fakeNetworkCallback)));
+    }
 
     // Add a test interface simulating networks
     wlanInterfaces.push_back(
         std::make_unique<TestWlanInterface>(GUID{0xc386c570, 0xf576, 0x4f7e, {0xbf, 0x19, 0xd2, 0x32, 0x3a, 0xf8, 0xdd, 0x19}}));
-    return std::make_unique<OperationHandler>(std::move(callbacks), std::move(wlanInterfaces));
+
+    return std::make_unique<OperationHandler>(std::move(observer), std::move(wlanInterfaces));
 }
 
 } // namespace ProxyWifi

--- a/lib/ProxyWifiServiceImpl.cpp
+++ b/lib/ProxyWifiServiceImpl.cpp
@@ -27,12 +27,13 @@ constexpr const char* GetProxyModeName(OperationMode mode)
     }
 }
 
-std::shared_ptr<OperationHandler> GetOperationHandler(const OperationMode proxyMode, ProxyWifiCallbacks callbacks)
+std::shared_ptr<OperationHandler> GetOperationHandler(
+    const OperationMode proxyMode, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer)
 {
     switch (proxyMode)
     {
     case OperationMode::Simulated:
-        return MakeManualTestOperationHandler(std::move(callbacks));
+        return MakeManualTestOperationHandler(std::move(fakeNetworkCallback), std::move(observer));
     case OperationMode::Normal:
     {
         std::shared_ptr<Wlansvc::WlanApiWrapper> wlansvc;
@@ -44,7 +45,7 @@ std::shared_ptr<OperationHandler> GetOperationHandler(const OperationMode proxyM
         {
             LOG_CAUGHT_EXCEPTION_MSG("Failed to get a Wlansvc handle. Will only support fake networks.");
         }
-        return MakeWlansvcOperationHandler(wlansvc, std::move(callbacks));
+        return MakeWlansvcOperationHandler(wlansvc, std::move(fakeNetworkCallback), std::move(observer));
     }
     default:
         throw std::runtime_error("Unsupported proxy mode selected");
@@ -58,9 +59,8 @@ WifiNetworkInfo::WifiNetworkInfo(const DOT11_SSID& ssid, const DOT11_MAC_ADDRESS
     memcpy_s(this->bssid, sizeof this->bssid, bssid, sizeof bssid);
 }
 
-ProxyWifiCommon::ProxyWifiCommon(OperationMode mode, ProxyWifiCallbacks callbacks)
-    : m_mode{mode},
-      m_operationHandler{GetOperationHandler(mode, std::move(callbacks))}
+ProxyWifiCommon::ProxyWifiCommon(OperationMode mode, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer)
+    : m_mode{mode}, m_operationHandler{GetOperationHandler(mode, std::move(fakeNetworkCallback), std::move(observer))}
 {
 }
 
@@ -99,9 +99,8 @@ ProxyWifiHyperVSettings::ProxyWifiHyperVSettings(const GUID& guestVmId)
 {
 }
 
-ProxyWifiHyperV::ProxyWifiHyperV(const ProxyWifiHyperVSettings& settings, ProxyWifiCallbacks callbacks)
-    : ProxyWifiCommon(settings.ProxyMode, std::move(callbacks)),
-      m_settings(settings)
+ProxyWifiHyperV::ProxyWifiHyperV(const ProxyWifiHyperVSettings& settings, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer)
+    : ProxyWifiCommon(settings.ProxyMode, std::move(fakeNetworkCallback), std::move(observer)), m_settings(settings)
 {
 }
 
@@ -129,8 +128,9 @@ ProxyWifiTcpSettings::ProxyWifiTcpSettings(const std::string& listenIp)
 {
 }
 
-ProxyWifiTcp::ProxyWifiTcp(const ProxyWifiTcpSettings& settings, ProxyWifiCallbacks callbacks)
-    : ProxyWifiCommon(settings.ProxyMode, std::move(callbacks)), m_settings(settings)
+ProxyWifiTcp::ProxyWifiTcp(
+    const ProxyWifiTcpSettings& settings, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer)
+    : ProxyWifiCommon(settings.ProxyMode, std::move(fakeNetworkCallback), std::move(observer)), m_settings(settings)
 {
 }
 
@@ -145,7 +145,8 @@ const ProxyWifiTcpSettings& ProxyWifiTcp::Settings() const
     return m_settings;
 }
 
-std::unique_ptr<ProxyWifiService> BuildProxyWifiService(const ProxyWifiHyperVSettings& settings, ProxyWifiCallbacks callbacks)
+std::unique_ptr<ProxyWifiService> BuildProxyWifiService(
+    const ProxyWifiHyperVSettings& settings, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer)
 {
     Log::Info(
         L"Building a Wifi proxy. Mode: %hs, Transport: HvSocket, VM Guid: %ws, Request port: %d, Notification port: %d",
@@ -153,10 +154,11 @@ std::unique_ptr<ProxyWifiService> BuildProxyWifiService(const ProxyWifiHyperVSet
         GuidToString(settings.GuestVmId).c_str(),
         settings.RequestResponsePort,
         settings.NotificationPort);
-    return std::make_unique<ProxyWifiHyperV>(settings, std::move(callbacks));
+    return std::make_unique<ProxyWifiHyperV>(settings, std::move(fakeNetworkCallback), std::move(observer));
 }
 
-std::unique_ptr<ProxyWifiService> BuildProxyWifiService(const ProxyWifiTcpSettings& settings, ProxyWifiCallbacks callbacks)
+std::unique_ptr<ProxyWifiService> BuildProxyWifiService(
+    const ProxyWifiTcpSettings& settings, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer)
 {
     Log::Info(
         L"Building a Wifi proxy. Mode: %hs, Transport: TCP, Listen IP: %hs, Request port: %d, Notification port: %d",
@@ -164,7 +166,7 @@ std::unique_ptr<ProxyWifiService> BuildProxyWifiService(const ProxyWifiTcpSettin
         settings.ListenIp.c_str(),
         settings.RequestResponsePort,
         settings.NotificationPort);
-    return std::make_unique<ProxyWifiTcp>(settings, std::move(callbacks));
+    return std::make_unique<ProxyWifiTcp>(settings, std::move(fakeNetworkCallback), std::move(observer));
 }
 
 } // namespace ProxyWifi

--- a/lib/ProxyWifiServiceImpl.hpp
+++ b/lib/ProxyWifiServiceImpl.hpp
@@ -15,7 +15,7 @@ namespace ProxyWifi {
 class ProxyWifiCommon: public ProxyWifiService
 {
 public:
-    ProxyWifiCommon(OperationMode mode, ProxyWifiCallbacks callbacks);
+    ProxyWifiCommon(OperationMode mode, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer);
     virtual ~ProxyWifiCommon();
 
     /// @brief Start the proxy.
@@ -39,7 +39,6 @@ protected:
 protected:
     std::thread m_proxy;
     OperationMode m_mode = OperationMode::Normal;
-    ProxyWifiCallbacks m_clientCallbacks;
     std::shared_ptr<OperationHandler> m_operationHandler;
     std::unique_ptr<Transport> m_transport;
 };
@@ -76,7 +75,7 @@ class ProxyWifiHyperV : public ProxyWifiCommon
 public:
     /// @brief Construct a new Proxy Wifi HyperV object.
     /// @param settings The settings controlling operations of the proxy.
-    explicit ProxyWifiHyperV(const ProxyWifiHyperVSettings& settings, ProxyWifiCallbacks callbacks);
+    explicit ProxyWifiHyperV(const ProxyWifiHyperVSettings& settings, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer);
 
     /// @brief Get HyperV specific proxy settings.
     const ProxyWifiHyperVSettings& Settings() const;
@@ -99,7 +98,7 @@ public:
     /// @brief Construct a new Proxy Wifi Tcp object.
     ///
     /// @param settings The settings controlling operations of the proxy.
-    explicit ProxyWifiTcp(const ProxyWifiTcpSettings& settings, ProxyWifiCallbacks callbacks);
+    explicit ProxyWifiTcp(const ProxyWifiTcpSettings& settings, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer);
 
     /// @brief TCP specific proxy settings.
     const ProxyWifiTcpSettings& Settings() const;

--- a/lib/ProxyWifiServiceImpl.hpp
+++ b/lib/ProxyWifiServiceImpl.hpp
@@ -15,7 +15,7 @@ namespace ProxyWifi {
 class ProxyWifiCommon: public ProxyWifiService
 {
 public:
-    ProxyWifiCommon(OperationMode mode, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer);
+    ProxyWifiCommon(OperationMode mode, FakeNetworkProvider fakeNetworkCallback, ProxyWifiObserver* pObserver);
     virtual ~ProxyWifiCommon();
 
     /// @brief Start the proxy.
@@ -75,7 +75,7 @@ class ProxyWifiHyperV : public ProxyWifiCommon
 public:
     /// @brief Construct a new Proxy Wifi HyperV object.
     /// @param settings The settings controlling operations of the proxy.
-    explicit ProxyWifiHyperV(const ProxyWifiHyperVSettings& settings, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer);
+    explicit ProxyWifiHyperV(const ProxyWifiHyperVSettings& settings, FakeNetworkProvider fakeNetworkCallback, ProxyWifiObserver* pObserver);
 
     /// @brief Get HyperV specific proxy settings.
     const ProxyWifiHyperVSettings& Settings() const;
@@ -98,7 +98,7 @@ public:
     /// @brief Construct a new Proxy Wifi Tcp object.
     ///
     /// @param settings The settings controlling operations of the proxy.
-    explicit ProxyWifiTcp(const ProxyWifiTcpSettings& settings, FakeNetworkProvider fakeNetworkCallback, std::shared_ptr<ProxyWifiObserver> observer);
+    explicit ProxyWifiTcp(const ProxyWifiTcpSettings& settings, FakeNetworkProvider fakeNetworkCallback, ProxyWifiObserver* pObserver);
 
     /// @brief TCP specific proxy settings.
     const ProxyWifiTcpSettings& Settings() const;

--- a/lib/WlansvcOperationHandler.hpp
+++ b/lib/WlansvcOperationHandler.hpp
@@ -15,8 +15,8 @@ namespace ProxyWifi {
 class WlansvcOperationHandler : public OperationHandler
 {
 public:
-    WlansvcOperationHandler(ProxyWifiCallbacks callbacks, std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces, std::shared_ptr<Wlansvc::WlanApiWrapper>& wlansvc)
-        : OperationHandler{std::move(callbacks), std::move(wlanInterfaces)}, m_wlansvc{wlansvc}
+    WlansvcOperationHandler(std::shared_ptr<ProxyWifiObserver> observer, std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces, std::shared_ptr<Wlansvc::WlanApiWrapper>& wlansvc)
+        : OperationHandler{std::move(observer), std::move(wlanInterfaces)}, m_wlansvc{wlansvc}
     {
         if (!m_wlansvc)
         {

--- a/lib/WlansvcOperationHandler.hpp
+++ b/lib/WlansvcOperationHandler.hpp
@@ -15,8 +15,8 @@ namespace ProxyWifi {
 class WlansvcOperationHandler : public OperationHandler
 {
 public:
-    WlansvcOperationHandler(std::shared_ptr<ProxyWifiObserver> observer, std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces, std::shared_ptr<Wlansvc::WlanApiWrapper>& wlansvc)
-        : OperationHandler{std::move(observer), std::move(wlanInterfaces)}, m_wlansvc{wlansvc}
+    WlansvcOperationHandler(ProxyWifiObserver* pObserver, std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces, std::shared_ptr<Wlansvc::WlanApiWrapper>& wlansvc)
+        : OperationHandler{pObserver, std::move(wlanInterfaces)}, m_wlansvc{wlansvc}
     {
         if (!m_wlansvc)
         {

--- a/test/TestOpHandler.cpp
+++ b/test/TestOpHandler.cpp
@@ -424,11 +424,11 @@ TEST_CASE("Notify the client on connection and disconnection", "[wlansvcOpHandle
 
     struct TestObserver : public ProxyWifiObserver
     {
-        void OnHostConnection(const GUID&, const DOT11_SSID&, DOT11_AUTH_ALGORITHM) noexcept override
+        void OnHostConnection(const ConnectCompleteArgs&) noexcept override
         {
             notifs.push_back({Notif::HostConnect, Type::None});
         }
-        void OnHostDisconnection(const GUID&, const DOT11_SSID&) noexcept override
+        void OnHostDisconnection(const DisconnectCompleteArgs&) noexcept override
         {
             notifs.push_back({Notif::HostDisconnect, Type::None});
         }
@@ -437,7 +437,7 @@ TEST_CASE("Notify the client on connection and disconnection", "[wlansvcOpHandle
             auto type = t == OperationType::GuestDirected ? Type::GuestDirected : Type::HostMirroring;
             notifs.push_back({Notif::GuestConnectRequest, type});
         }
-        void OnGuestConnectionCompletion(OperationType t, OperationStatus, const GUID&, const DOT11_SSID&, DOT11_AUTH_ALGORITHM) noexcept override
+        void OnGuestConnectionCompletion(OperationType t, OperationStatus, const ConnectCompleteArgs&) noexcept override
         {
             auto type = t == OperationType::GuestDirected ? Type::GuestDirected : Type::HostMirroring;
             notifs.push_back({Notif::GuestConnectComplete, type});
@@ -447,7 +447,7 @@ TEST_CASE("Notify the client on connection and disconnection", "[wlansvcOpHandle
             auto type = t == OperationType::GuestDirected ? Type::GuestDirected : Type::HostMirroring;
             notifs.push_back({Notif::GuestDisconnectRequest, type});
         }
-        void OnGuestDisconnectionCompletion(OperationType t, OperationStatus, const GUID&, const DOT11_SSID&) noexcept override
+        void OnGuestDisconnectionCompletion(OperationType t, OperationStatus, const DisconnectCompleteArgs&) noexcept override
         {
             auto type = t == OperationType::GuestDirected ? Type::GuestDirected : Type::HostMirroring;
             notifs.push_back({Notif::GuestDisconnectComplete, type});
@@ -577,14 +577,14 @@ TEST_CASE("Provide the authentication algorithm on host connections", "[wlansvcO
 
     struct TestObserver: public ProxyWifiObserver
     {
-        void OnHostConnection(const GUID&, const DOT11_SSID&, DOT11_AUTH_ALGORITHM auth) noexcept override
+        void OnHostConnection(const ConnectCompleteArgs& connectInfo) noexcept override
         {
-            notifParams.push_back({EventSource::Host, auth});
+            notifParams.push_back({EventSource::Host, connectInfo.authAlgo});
         }
 
-        void OnGuestConnectionCompletion(OperationType, OperationStatus, const GUID&, const DOT11_SSID&, DOT11_AUTH_ALGORITHM auth) noexcept override
+        void OnGuestConnectionCompletion(OperationType, OperationStatus, const ConnectCompleteArgs& connectInfo) noexcept override
         {
-            notifParams.push_back({EventSource::Guest, auth});
+            notifParams.push_back({EventSource::Guest, connectInfo.authAlgo});
         }
 
         std::vector<std::pair<EventSource, DOT11_AUTH_ALGORITHM>> notifParams;
@@ -642,7 +642,7 @@ TEST_CASE("Notify client for initially connected networks", "[wlansvcOpHandler][
 
     struct TestObserver: public ProxyWifiObserver
     {
-        void OnHostConnection(const GUID&, const DOT11_SSID&, DOT11_AUTH_ALGORITHM) noexcept override
+        void OnHostConnection(const ConnectCompleteArgs&) noexcept override
         {
             hostConnect++;
         }
@@ -669,7 +669,7 @@ TEST_CASE("Initial notifications cannot deadlock a cient", "[wlansvcOpHandler][c
 
     struct TestObserver: public ProxyWifiObserver
     {
-        void OnHostConnection(const GUID&, const DOT11_SSID&, DOT11_AUTH_ALGORITHM) noexcept override
+        void OnHostConnection(const ConnectCompleteArgs&) noexcept override
         {
             for (auto i = 0; i < 10; ++i)
             {
@@ -858,13 +858,13 @@ TEST_CASE("Notifications for fake networks use FakeInterfaceGuid", "[wlansvcOpHa
 
     struct TestObserver: public ProxyWifiObserver
     {
-        void OnGuestDisconnectionCompletion(OperationType, OperationStatus, const GUID& interfaceGuid, const DOT11_SSID&) noexcept override
+        void OnGuestDisconnectionCompletion(OperationType, OperationStatus, const DisconnectCompleteArgs& disconnectInfo) noexcept override
         {
-            guid = interfaceGuid;
+            guid = disconnectInfo.interfaceGuid;
         }
-        void OnGuestConnectionCompletion(OperationType, OperationStatus, const GUID& interfaceGuid, const DOT11_SSID&, DOT11_AUTH_ALGORITHM) noexcept override
+        void OnGuestConnectionCompletion(OperationType, OperationStatus, const ConnectCompleteArgs& connectInfo) noexcept override
         {
-            guid = interfaceGuid;
+            guid = connectInfo.interfaceGuid;
         }
         GUID guid{};
     };

--- a/test/TestOpHandler.cpp
+++ b/test/TestOpHandler.cpp
@@ -432,7 +432,7 @@ TEST_CASE("Notify the client on connection and disconnection", "[wlansvcOpHandle
         {
             notifs.push_back({Notif::HostDisconnect, Type::None});
         }
-        void OnGuestConnectionRequest(OperationType t, const DOT11_SSID&) noexcept override
+        void OnGuestConnectionRequest(OperationType t, const ConnectRequestArgs&) noexcept override
         {
             auto type = t == OperationType::GuestDirected ? Type::GuestDirected : Type::HostMirroring;
             notifs.push_back({Notif::GuestConnectRequest, type});
@@ -442,7 +442,7 @@ TEST_CASE("Notify the client on connection and disconnection", "[wlansvcOpHandle
             auto type = t == OperationType::GuestDirected ? Type::GuestDirected : Type::HostMirroring;
             notifs.push_back({Notif::GuestConnectComplete, type});
         }
-        void OnGuestDisconnectionRequest(OperationType t, DOT11_SSID) noexcept override
+        void OnGuestDisconnectionRequest(OperationType t, const DisconnectRequestArgs&) noexcept override
         {
             auto type = t == OperationType::GuestDirected ? Type::GuestDirected : Type::HostMirroring;
             notifs.push_back({Notif::GuestDisconnectRequest, type});

--- a/test/TestOpHandler.cpp
+++ b/test/TestOpHandler.cpp
@@ -17,9 +17,9 @@ using namespace std::chrono_literals;
 using namespace ProxyWifi;
 
 // Setup helper functions
-std::unique_ptr<OperationHandler> MakeUnitTestOperationHandler(ProxyWifiCallbacks callbacks, std::shared_ptr<Wlansvc::WlanApiWrapper> fakeWlansvc)
+std::unique_ptr<OperationHandler> MakeUnitTestOperationHandler(std::shared_ptr<Wlansvc::WlanApiWrapper> fakeWlansvc, FakeNetworkProvider provider = {}, std::shared_ptr<ProxyWifiObserver> observer = {})
 {
-    return MakeWlansvcOperationHandler(fakeWlansvc, std::move(callbacks));
+    return MakeWlansvcOperationHandler(fakeWlansvc, std::move(provider), std::move(observer));
 }
 
 ConnectRequest MakeWpa2PskConnectRequest(const Ssid& ssid)
@@ -71,7 +71,7 @@ DisconnectRequest MakeDisconnectRequest(uint32_t sessionId)
 
 TEST_CASE("The WlanApiWrapper is optionnal", "[wlansvcOpHandler]")
 {
-    auto opHandler = MakeWlansvcOperationHandler(std::shared_ptr<Wlansvc::WlanApiWrapper>{}, {});
+    auto opHandler = MakeWlansvcOperationHandler(std::shared_ptr<Wlansvc::WlanApiWrapper>{}, {}, {});
     CHECK(opHandler);
 }
 
@@ -82,7 +82,7 @@ TEST_CASE("Process a scan requests", "[wlansvcOpHandler]")
     SECTION("No visible networks")
     {
         auto fakeWlansvc = std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1});
-        auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+        auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
         auto scanResponse = opHandler->HandleScanRequest(ScanRequest{std::move(body)});
 
         CHECK(scanResponse->num_bss == 0);
@@ -93,7 +93,7 @@ TEST_CASE("Process a scan requests", "[wlansvcOpHandler]")
     {
         auto fakeWlansvc =
             std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_wpa2PskNetwork, Mock::c_openNetwork});
-        auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+        auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
 
         auto scanResponse = opHandler->HandleScanRequest(ScanRequest{std::move(body)});
         CHECK(scanResponse->num_bss == 2);
@@ -115,7 +115,7 @@ TEST_CASE("Process a scan requests", "[wlansvcOpHandler]")
     SECTION("Replace unsupported networks")
     {
         auto fakeWlansvc = std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_enterpriseNetwork});
-        auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+        auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
 
         auto scanResponse = opHandler->HandleScanRequest(ScanRequest{std::move(body)});
 
@@ -142,14 +142,9 @@ TEST_CASE("Process a scan requests", "[wlansvcOpHandler]")
         Ssid ssid{"ethernet"};
         DOT11_MAC_ADDRESS bssid{0, 0, 0, 0, 0, 1};
 
-        auto opHandler = MakeUnitTestOperationHandler(
-            {{},
-             {},
-             {},
-             [&] {
-                 return std::vector<WifiNetworkInfo>{{static_cast<DOT11_SSID>(ssid), bssid}};
-             }},
-            fakeWlansvc);
+        auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc, [&] {
+            return std::vector<WifiNetworkInfo>{{static_cast<DOT11_SSID>(ssid), bssid}};
+        });
 
         auto scanResponse = opHandler->HandleScanRequest(ScanRequest{std::move(body)});
 
@@ -171,7 +166,7 @@ TEST_CASE("Handle scan on multiple interfaces", "[wlansvcOpHandler][multiInterfa
     SECTION("No visible networks")
     {
         auto fakeWlansvc = std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1, Mock::c_intf2});
-        auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+        auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
 
         auto scanResponse = opHandler->HandleScanRequest(ScanRequest{std::move(body)});
     }
@@ -180,7 +175,7 @@ TEST_CASE("Handle scan on multiple interfaces", "[wlansvcOpHandler][multiInterfa
         auto fakeWlansvc = std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1, Mock::c_intf2});
         fakeWlansvc->AddNetwork(Mock::c_intf1, Mock::c_openNetwork);
         fakeWlansvc->AddNetwork(Mock::c_intf2, Mock::c_wpa2PskNetwork);
-        auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+        auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
 
         auto scanResponse = opHandler->HandleScanRequest(ScanRequest{std::move(body)});
         REQUIRE(scanResponse->num_bss == 2);
@@ -193,7 +188,7 @@ TEST_CASE("Handle scan on multiple interfaces", "[wlansvcOpHandler][multiInterfa
         auto fakeWlansvc =
             std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1, Mock::c_intf2}, std::vector{Mock::c_wpa2PskNetwork});
         fakeWlansvc->AddNetwork(Mock::c_intf1, Mock::c_openNetwork);
-        auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+        auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
 
         auto scanResponse = opHandler->HandleScanRequest(ScanRequest{std::move(body)});
         REQUIRE(scanResponse->num_bss == 2);
@@ -211,14 +206,9 @@ TEST_CASE("Handle scan on multiple interfaces", "[wlansvcOpHandler][multiInterfa
         DOT11_MAC_ADDRESS bssid{};
         std::copy(Mock::c_wpa2PskNetwork.bss.bssid.cbegin(), Mock::c_wpa2PskNetwork.bss.bssid.cend(), bssid);
 
-        auto opHandler = MakeUnitTestOperationHandler(
-            {{},
-             {},
-             {},
-             [&] {
-                 return std::vector<WifiNetworkInfo>{{static_cast<DOT11_SSID>(ssid), bssid}};
-             }},
-            fakeWlansvc);
+        auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc, [&] {
+            return std::vector<WifiNetworkInfo>{{static_cast<DOT11_SSID>(ssid), bssid}};
+        });
 
         auto scanResponse = opHandler->HandleScanRequest(ScanRequest{std::move(body)});
         REQUIRE(scanResponse->num_bss == 2);
@@ -235,7 +225,7 @@ TEST_CASE("Process a connection request")
 {
     auto fakeWlansvc =
         std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_wpa2PskNetwork, Mock::c_openNetwork});
-    auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+    auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
     auto connectRequest = MakeWpa2PskConnectRequest(Mock::c_wpa2PskNetwork.bss.ssid);
 
     // Guest connection request on new network result in call to wlansvc
@@ -270,14 +260,9 @@ TEST_CASE("Handle connect requests with multiple interfaces", "[wlansvcOpHandler
     fakeWlansvc->AddNetwork(Mock::c_intf2, Mock::c_wpa2PskNetwork);
 
     DOT11_MAC_ADDRESS bssid{0, 0, 0, 0, 0, 1};
-    auto opHandler = MakeUnitTestOperationHandler(
-        {{},
-         {},
-         {},
-         [&] {
-             return std::vector<WifiNetworkInfo>{{Mock::c_pizzaNetwork.network.dot11Ssid, bssid}};
-         }},
-        fakeWlansvc);
+    auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc, [&] {
+        return std::vector<WifiNetworkInfo>{{Mock::c_pizzaNetwork.network.dot11Ssid, bssid}};
+    });
 
     SECTION("First interface can connect")
     {
@@ -313,12 +298,12 @@ TEST_CASE("Process a disconnect request", "[wlansvcOpHandler]")
 {
     auto fakeWlansvc =
         std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_wpa2PskNetwork, Mock::c_openNetwork});
-    auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+    auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
 
     auto connectRequest = MakeWpa2PskConnectRequest(Mock::c_wpa2PskNetwork.bss.ssid);
     auto disconnectRequest = MakeDisconnectRequest(1);
 
-    // Guest connection request on new network result in call to wlansvc
+    // Guest disconnection request on new network result in call to wlansvc
     SECTION("Disconnect the host if the network was connected by the guest")
     {
         auto connectResponse = opHandler->HandleConnectRequest(connectRequest);
@@ -382,13 +367,9 @@ TEST_CASE("Handle disconnect requests with multiple interfaces", "[wlansvcOpHand
     Ssid ssid{"ethernet"};
     DOT11_MAC_ADDRESS bssid{0, 0, 0, 0, 0, 1};
     auto opHandler = MakeUnitTestOperationHandler(
-        {{},
-         {},
-         {},
-         [&] {
+         fakeWlansvc, [&] {
              return std::vector<WifiNetworkInfo>{{static_cast<DOT11_SSID>(ssid), bssid}};
-         }},
-        fakeWlansvc);
+         });
 
     SECTION("Only disconnect the guest connected interface")
     {
@@ -420,44 +401,85 @@ TEST_CASE("Handle disconnect requests with multiple interfaces", "[wlansvcOpHand
     }
 }
 
-TEST_CASE("Notify client on host connection and disconnection", "[wlansvcOpHandler][clientNotification]")
+TEST_CASE("Notify the client on connection and disconnection", "[wlansvcOpHandler][clientNotification]")
 {
     auto fakeWlansvc =
         std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_wpa2PskNetwork, Mock::c_openNetwork});
 
-    int hostConnect = 0;
-    int guestConnect = 0;
-    int hostDisconnect = 0;
-    int guestDisconnect = 0;
-    auto opHandler = MakeUnitTestOperationHandler(
-        {[&](auto origin, auto) { origin == EventSource::Host ? ++hostConnect : ++guestConnect; },
-         [&](auto origin, auto) { origin == EventSource::Host ? ++hostDisconnect : ++guestDisconnect; },
-         {},
-         {}},
-        fakeWlansvc);
+    enum class Notif
+    {
+        HostConnect,
+        HostDisconnect,
+        GuestConnectRequest,
+        GuestConnectComplete,
+        GuestDisconnectRequest,
+        GuestDisconnectComplete
+    };
+    enum class Type
+    {
+        None,
+        GuestDirected,
+        HostMirroring
+    };
 
+    struct TestObserver : public ProxyWifiObserver
+    {
+        void OnHostConnection(const GUID&, const DOT11_SSID&, DOT11_AUTH_ALGORITHM) noexcept override
+        {
+            notifs.push_back({Notif::HostConnect, Type::None});
+        }
+        void OnHostDisconnection(const GUID&, const DOT11_SSID&) noexcept override
+        {
+            notifs.push_back({Notif::HostDisconnect, Type::None});
+        }
+        void OnGuestConnectionRequest(OperationType t, const DOT11_SSID&) noexcept override
+        {
+            auto type = t == OperationType::GuestDirected ? Type::GuestDirected : Type::HostMirroring;
+            notifs.push_back({Notif::GuestConnectRequest, type});
+        }
+        void OnGuestConnectionCompletion(OperationType t, OperationStatus, const GUID&, const DOT11_SSID&, DOT11_AUTH_ALGORITHM) noexcept override
+        {
+            auto type = t == OperationType::GuestDirected ? Type::GuestDirected : Type::HostMirroring;
+            notifs.push_back({Notif::GuestConnectComplete, type});
+        }
+        void OnGuestDisconnectionRequest(OperationType t, DOT11_SSID) noexcept override
+        {
+            auto type = t == OperationType::GuestDirected ? Type::GuestDirected : Type::HostMirroring;
+            notifs.push_back({Notif::GuestDisconnectRequest, type});
+        }
+        void OnGuestDisconnectionCompletion(OperationType t, OperationStatus, const GUID&, const DOT11_SSID&) noexcept override
+        {
+            auto type = t == OperationType::GuestDirected ? Type::GuestDirected : Type::HostMirroring;
+            notifs.push_back({Notif::GuestDisconnectComplete, type});
+        }
+
+        std::vector<std::pair<Notif, Type>> notifs;
+    };
+
+    auto observer = std::make_shared<TestObserver>();
+    auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc, {}, observer);
     auto connectRequest = MakeOpenConnectRequest(Mock::c_openNetwork.bss.ssid);
     auto disconnectRequest = MakeDisconnectRequest(1);
 
-    // Guest connection request on new network result in call to wlansvc
     SECTION("Notifications on guest initiated operations")
     {
         auto connectResponse = opHandler->HandleConnectRequest(connectRequest);
         opHandler->DrainClientNotifications();
         CHECK(connectResponse->result_code == WI_EnumValue(WlanStatus::Success));
-        CHECK(fakeWlansvc->callCount.connect == 1);
-        CHECK(hostConnect == 1);
-        CHECK(guestConnect == 1);
-        CHECK(hostDisconnect == 0);
-        CHECK(guestDisconnect == 0);
+        CHECK(
+            observer->notifs == std::vector<std::pair<Notif, Type>>{
+                                    {Notif::GuestConnectRequest, Type::GuestDirected},
+                                    {Notif::HostConnect, Type::None},
+                                    {Notif::GuestConnectComplete, Type::GuestDirected}});
 
+        observer->notifs.clear();
         auto disconnectResponse = opHandler->HandleDisconnectRequest(disconnectRequest);
         opHandler->DrainClientNotifications();
-        CHECK(fakeWlansvc->callCount.disconnect == 1);
-        CHECK(hostConnect == 1);
-        CHECK(guestConnect == 1);
-        CHECK(hostDisconnect == 1);
-        CHECK(guestDisconnect == 1);
+        CHECK(
+            observer->notifs == std::vector<std::pair<Notif, Type>>{
+                                    {Notif::GuestDisconnectRequest, Type::GuestDirected},
+                                    {Notif::HostDisconnect, Type::None},
+                                    {Notif::GuestDisconnectComplete, Type::GuestDirected}});
     }
 
     SECTION("Notifications on host initiated operations")
@@ -465,19 +487,16 @@ TEST_CASE("Notify client on host connection and disconnection", "[wlansvcOpHandl
         fakeWlansvc->ConnectHost(Mock::c_intf1, Mock::c_wpa2PskNetwork.bss.ssid);
         fakeWlansvc->WaitForNotifComplete();
         opHandler->DrainClientNotifications();
-        CHECK(hostConnect == 1);
-        CHECK(guestConnect == 0);
-        CHECK(hostDisconnect == 0);
-        CHECK(guestDisconnect == 0);
+        CHECK(observer->notifs == std::vector<std::pair<Notif, Type>>{{Notif::HostConnect, Type::None}});
 
+        observer->notifs.clear();
+
+        auto disconnectResponse = opHandler->HandleDisconnectRequest(disconnectRequest);
         fakeWlansvc->DisconnectHost(Mock::c_intf1);
         fakeWlansvc->WaitForNotifComplete();
         opHandler->DrainClientNotifications();
 
-        CHECK(hostConnect == 1);
-        CHECK(guestConnect == 0);
-        CHECK(hostDisconnect == 1);
-        CHECK(guestDisconnect == 0);
+        CHECK(observer->notifs == std::vector<std::pair<Notif,Type>>{{Notif::HostDisconnect, Type::None}});
     }
 
     SECTION("Notifications on mirroring operations")
@@ -485,37 +504,64 @@ TEST_CASE("Notify client on host connection and disconnection", "[wlansvcOpHandl
         fakeWlansvc->ConnectHost(Mock::c_intf1, Mock::c_openNetwork.bss.ssid);
         fakeWlansvc->WaitForNotifComplete();
         opHandler->DrainClientNotifications();
-        CHECK(hostConnect == 1);
-        CHECK(guestConnect == 0);
-        CHECK(hostDisconnect == 0);
-        CHECK(guestDisconnect == 0);
 
         auto connectResponse = opHandler->HandleConnectRequest(connectRequest);
         opHandler->DrainClientNotifications();
         CHECK(connectResponse->result_code == WI_EnumValue(WlanStatus::Success));
         CHECK(fakeWlansvc->callCount.connect == 0);
-        CHECK(hostConnect == 1);
-        CHECK(guestConnect == 1);
-        CHECK(hostDisconnect == 0);
-        CHECK(guestDisconnect == 0);
+        CHECK(observer->notifs == std::vector<std::pair<Notif, Type>>{
+                                    {Notif::HostConnect, Type::None},
+                                    {Notif::GuestConnectRequest, Type::HostMirroring},
+                                    {Notif::GuestConnectComplete, Type::HostMirroring}});
+
+        observer->notifs.clear();
 
         auto disconnectResponse = opHandler->HandleDisconnectRequest(disconnectRequest);
         opHandler->DrainClientNotifications();
         CHECK(fakeWlansvc->callCount.disconnect == 0);
-        CHECK(hostConnect == 1);
-        CHECK(guestConnect == 1);
-        CHECK(hostDisconnect == 0);
-        CHECK(guestDisconnect == 1);
+        CHECK(observer->notifs == std::vector<std::pair<Notif, Type>>{
+                {Notif::GuestDisconnectRequest, Type::HostMirroring}, {Notif::GuestDisconnectComplete, Type::HostMirroring}});
+
+        observer->notifs.clear();
 
         fakeWlansvc->DisconnectHost(Mock::c_intf1);
         fakeWlansvc->WaitForNotifComplete();
         opHandler->DrainClientNotifications();
 
-        CHECK(hostConnect == 1);
-        CHECK(guestConnect == 1);
-        CHECK(hostDisconnect == 1);
-        CHECK(guestDisconnect == 1);
+        CHECK(observer->notifs == std::vector<std::pair<Notif, Type>>{{Notif::HostDisconnect, Type::None}});
     }
+}
+
+TEST_CASE("Notify client for guest scans", "[wlansvcOpHandler][clientNotification]")
+{
+    auto fakeWlansvc = std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_wpa2PskNetwork});
+
+    enum class Notif
+    {
+        ScanRequest,
+        ScanComplete
+    };
+
+    struct TestObserver : public ProxyWifiObserver
+    {
+        void OnGuestScanRequest() noexcept override
+        {
+            notifs.push_back(Notif::ScanRequest);
+        }
+        void OnGuestScanCompletion(OperationStatus) noexcept override
+        {
+            notifs.push_back(Notif::ScanComplete);
+        }
+        std::vector<Notif> notifs;
+    };
+
+    auto observer = std::make_shared<TestObserver>();
+    auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc, {}, observer);
+    auto body = std::vector<uint8_t>(sizeof(proxy_wifi_scan_request));
+    auto scanResponse = opHandler->HandleScanRequest(ScanRequest{std::move(body)});
+    opHandler->DrainClientNotifications();
+
+    CHECK(observer->notifs == std::vector{Notif::ScanRequest, Notif::ScanComplete});
 }
 
 TEST_CASE("Provide the authentication algorithm on host connections", "[wlansvcOpHandler][clientNotification]")
@@ -523,18 +569,38 @@ TEST_CASE("Provide the authentication algorithm on host connections", "[wlansvcO
     auto fakeWlansvc =
         std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_wpa2PskNetwork, Mock::c_openNetwork, Mock::c_enterpriseNetwork});
 
-    std::vector<std::pair<EventSource, OnConnectionArgs>> notifParams;
-    auto opHandler = MakeUnitTestOperationHandler({[&](auto origin, auto p) { notifParams.push_back({origin, p}); }, {}, {}, {}}, fakeWlansvc);
+    enum class EventSource
+    {
+        Host,
+        Guest
+    };
 
+    struct TestObserver: public ProxyWifiObserver
+    {
+        void OnHostConnection(const GUID&, const DOT11_SSID&, DOT11_AUTH_ALGORITHM auth) noexcept override
+        {
+            notifParams.push_back({EventSource::Host, auth});
+        }
+
+        void OnGuestConnectionCompletion(OperationType, OperationStatus, const GUID&, const DOT11_SSID&, DOT11_AUTH_ALGORITHM auth) noexcept override
+        {
+            notifParams.push_back({EventSource::Guest, auth});
+        }
+
+        std::vector<std::pair<EventSource, DOT11_AUTH_ALGORITHM>> notifParams;
+    };
+
+    auto observer = std::make_shared<TestObserver>();
+    auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc, {}, observer);
 
     SECTION("Correct auth algo for host wpa2psk connection")
     {
         fakeWlansvc->ConnectHost(Mock::c_intf1, Mock::c_wpa2PskNetwork.bss.ssid);
         fakeWlansvc->WaitForNotifComplete();
         opHandler->DrainClientNotifications();
-        REQUIRE(notifParams.size() == 1);
-        CHECK(notifParams[0].first == EventSource::Host);
-        CHECK(notifParams[0].second.authAlgo == DOT11_AUTH_ALGO_RSNA_PSK);
+        REQUIRE(observer->notifParams.size() == 1);
+        CHECK(observer->notifParams[0].first == EventSource::Host);
+        CHECK(observer->notifParams[0].second == DOT11_AUTH_ALGO_RSNA_PSK);
     }
 
     SECTION("Correct auth algo for host open connection")
@@ -542,9 +608,9 @@ TEST_CASE("Provide the authentication algorithm on host connections", "[wlansvcO
         fakeWlansvc->ConnectHost(Mock::c_intf1, Mock::c_openNetwork.bss.ssid);
         fakeWlansvc->WaitForNotifComplete();
         opHandler->DrainClientNotifications();
-        REQUIRE(notifParams.size() == 1);
-        CHECK(notifParams[0].first == EventSource::Host);
-        CHECK(notifParams[0].second.authAlgo == DOT11_AUTH_ALGO_80211_OPEN);
+        REQUIRE(observer->notifParams.size() == 1);
+        CHECK(observer->notifParams[0].first == EventSource::Host);
+        CHECK(observer->notifParams[0].second == DOT11_AUTH_ALGO_80211_OPEN);
     }
 
     SECTION("Auth algo is adapted to what the guest sees")
@@ -552,83 +618,21 @@ TEST_CASE("Provide the authentication algorithm on host connections", "[wlansvcO
         fakeWlansvc->ConnectHost(Mock::c_intf1, Mock::c_enterpriseNetwork.bss.ssid);
         fakeWlansvc->WaitForNotifComplete();
         opHandler->DrainClientNotifications();
-        REQUIRE(notifParams.size() == 1);
-        CHECK(notifParams[0].first == EventSource::Host);
-        CHECK(notifParams[0].second.authAlgo == DOT11_AUTH_ALGO_RSNA_PSK);
+        REQUIRE(observer->notifParams.size() == 1);
+        CHECK(observer->notifParams[0].first == EventSource::Host);
+        CHECK(observer->notifParams[0].second == DOT11_AUTH_ALGO_RSNA_PSK);
     }
 
     SECTION("Correct auth algo for guest connection")
     {
         auto connectRequest = MakeWpa2PskConnectRequest(Mock::c_wpa2PskNetwork.bss.ssid);
         auto connectResponse = opHandler->HandleConnectRequest(connectRequest);
-        REQUIRE(notifParams.size() == 2);
-        CHECK(notifParams[0].first == EventSource::Host);
-        CHECK(notifParams[0].second.authAlgo == DOT11_AUTH_ALGO_RSNA_PSK);
-        CHECK(notifParams[1].first == EventSource::Guest);
-        CHECK(notifParams[1].second.authAlgo == DOT11_AUTH_ALGO_RSNA_PSK);
+        REQUIRE(observer->notifParams.size() == 2);
+        CHECK(observer->notifParams[0].first == EventSource::Host);
+        CHECK(observer->notifParams[0].second == DOT11_AUTH_ALGO_RSNA_PSK);
+        CHECK(observer->notifParams[1].first == EventSource::Guest);
+        CHECK(observer->notifParams[1].second == DOT11_AUTH_ALGO_RSNA_PSK);
     }
-}
-
-TEST_CASE("Notify client for guest directed connection progress", "[wlansvcOpHandler][clientNotification]")
-{
-    auto fakeWlansvc =
-        std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_wpa2PskNetwork});
-
-    auto starting = 0;
-    auto succeeded = 0;
-    auto opHandler = MakeUnitTestOperationHandler(
-        {{},
-         {},
-         [&](auto status) {
-             if (status == GuestConnectStatus::Starting)
-             {
-                 ++starting;
-             }
-             else if (status == GuestConnectStatus::Succeeded)
-             {
-                 ++succeeded;
-             }
-             else
-             {
-                 CHECK(false);
-             }
-         },
-         {}},
-        fakeWlansvc);
-
-    auto connectRequest = MakeWpa2PskConnectRequest(Mock::c_wpa2PskNetwork.bss.ssid);
-    auto connectResponse = opHandler->HandleConnectRequest(connectRequest);
-    CHECK(connectResponse->result_code == WI_EnumValue(WlanStatus::Success));
-    CHECK(fakeWlansvc->callCount.connect == 1);
-    CHECK(starting == 1);
-    CHECK(succeeded == 1);
-}
-
-TEST_CASE("Notification for guest directed connection are in order", "[wlansvcOpHandler][clientNotification]")
-{
-    auto fakeWlansvc =
-        std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_wpa2PskNetwork});
-
-    enum class TestNotif
-    {
-        HostConnected,
-        GuestConnected,
-        ConnectStarting,
-        ConnectSucceeded,
-    };
-    std::vector<TestNotif> notifs;
-    auto opHandler = MakeUnitTestOperationHandler(
-        {[&](auto origin, auto) { notifs.push_back(origin == EventSource::Host ? TestNotif::HostConnected : TestNotif::GuestConnected); },
-         {},
-         [&](auto status) { notifs.push_back(status == GuestConnectStatus::Starting ? TestNotif::ConnectStarting : TestNotif::ConnectSucceeded); },
-         {}},
-        fakeWlansvc);
-
-    auto connectRequest = MakeWpa2PskConnectRequest(Mock::c_wpa2PskNetwork.bss.ssid);
-    auto connectResponse = opHandler->HandleConnectRequest(connectRequest);
-    CHECK(connectResponse->result_code == WI_EnumValue(WlanStatus::Success));
-    CHECK(fakeWlansvc->callCount.connect == 1);
-    CHECK(notifs == std::vector{TestNotif::ConnectStarting, TestNotif::HostConnected, TestNotif::GuestConnected, TestNotif::ConnectSucceeded});
 }
 
 TEST_CASE("Notify client for initially connected networks", "[wlansvcOpHandler][clientNotification]")
@@ -636,24 +640,23 @@ TEST_CASE("Notify client for initially connected networks", "[wlansvcOpHandler][
     auto fakeWlansvc =
         std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_wpa2PskNetwork, Mock::c_openNetwork});
 
+    struct TestObserver: public ProxyWifiObserver
+    {
+        void OnHostConnection(const GUID&, const DOT11_SSID&, DOT11_AUTH_ALGORITHM) noexcept override
+        {
+            hostConnect++;
+        }
+        int hostConnect = 0;
+    };
+
+    auto observer = std::make_shared<TestObserver>();
     fakeWlansvc->ConnectHost(Mock::c_intf1, Mock::c_wpa2PskNetwork.bss.ssid);
     fakeWlansvc->WaitForNotifComplete();
-    int hostConnect = 0;
-    int guestConnect = 0;
-    int hostDisconnect = 0;
-    int guestDisconnect = 0;
-    auto opHandler = MakeUnitTestOperationHandler(
-        {[&](auto origin, auto) { origin == EventSource::Host ? ++hostConnect : ++guestConnect; },
-         [&](auto origin, auto) { origin == EventSource::Host ? ++hostDisconnect : ++guestDisconnect; },
-         {},
-         {}},
-        fakeWlansvc);
+
+    auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc, {}, observer);
     opHandler->DrainClientNotifications();
 
-    CHECK(hostConnect == 1);
-    CHECK(guestConnect == 0);
-    CHECK(hostDisconnect == 0);
-    CHECK(guestDisconnect == 0);
+    CHECK(observer->hostConnect == 1);
 }
 
 TEST_CASE("Initial notifications cannot deadlock a cient", "[wlansvcOpHandler][clientNotification]")
@@ -664,46 +667,48 @@ TEST_CASE("Initial notifications cannot deadlock a cient", "[wlansvcOpHandler][c
     fakeWlansvc->ConnectHost(Mock::c_intf1, Mock::c_wpa2PskNetwork.bss.ssid);
     fakeWlansvc->WaitForNotifComplete();
 
-    wil::srwlock clientLock;
-    bool noDeadlock = false;
+    struct TestObserver: public ProxyWifiObserver
+    {
+        void OnHostConnection(const GUID&, const DOT11_SSID&, DOT11_AUTH_ALGORITHM) noexcept override
+        {
+            for (auto i = 0; i < 10; ++i)
+            {
+                auto lock = clientLock.try_lock_exclusive();
+                if (lock)
+                {
+                    noDeadlock = true;
+                    return;
+                }
+                std::this_thread::sleep_for(10ms);
+            }
+        }
+        wil::srwlock clientLock;
+        bool noDeadlock = false;
+    };
+
+    auto observer = std::make_shared<TestObserver>();
     auto opHandler = [&]() {
-        auto lock = clientLock.lock_exclusive();
-        return MakeUnitTestOperationHandler(
-            {[&](auto, auto) {
-                 for (auto i = 0; i < 10; ++i)
-                 {
-                     auto lock = clientLock.try_lock_exclusive();
-                     if (lock)
-                     {
-                         noDeadlock = true;
-                         return;
-                     }
-                     std::this_thread::sleep_for(10ms);
-                 }
-             },
-             {},
-             {},
-             {}},
-            fakeWlansvc);
+        auto lock = observer->clientLock.lock_exclusive();
+        return MakeUnitTestOperationHandler(fakeWlansvc, {}, observer);
     }();
 
     opHandler->DrainClientNotifications();
-    CHECK(noDeadlock);
+    CHECK(observer->noDeadlock);
 }
 
 TEST_CASE("Handle graciously non-expected wlansvc notifications", "[wlansvcOpHandler]")
 {
     auto fakeWlansvc =
         std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_wpa2PskNetwork, Mock::c_openNetwork});
-    auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+    auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
 
-    SECTION("Do crash on spontaneous scan complete notification")
+    SECTION("Do not crash on spontaneous scan complete notification")
     {
         fakeWlansvc->Scan(Mock::c_intf1);
         fakeWlansvc->WaitForNotifComplete();
     }
 
-    SECTION("Do crash on spontaneous connection complete notification")
+    SECTION("Do not crash on spontaneous connection complete notification")
     {
         fakeWlansvc->ConnectHost(Mock::c_intf1, Mock::c_wpa2PskNetwork.bss.ssid);
         fakeWlansvc->WaitForNotifComplete();
@@ -713,7 +718,7 @@ TEST_CASE("Handle graciously non-expected wlansvc notifications", "[wlansvcOpHan
 TEST_CASE("Don't notify guest on host disconnection", "[wlansvcOpHandler]")
 {
     auto fakeWlansvc = std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_wpa2PskNetwork});
-    auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+    auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
 
     auto callCount = 0;
     // An event is needed (and not only `WaitForNotifComplete`) since the callback is
@@ -758,7 +763,7 @@ TEST_CASE("Don't notify guest on host disconnection", "[wlansvcOpHandler]")
 TEST_CASE("Notify guest on signal quality change", "[wlansvcOpHandler]")
 {
     auto fakeWlansvc = std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_wpa2PskNetwork});
-    auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+    auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
 
     unsigned long signalQuality = 80;
     int8_t rssi = -60; // (rssi + 100) * 2 = signalQuality
@@ -799,7 +804,7 @@ TEST_CASE("Notify guest on signal quality change", "[wlansvcOpHandler]")
 TEST_CASE("Ignore notification from other interfaces", "[wlansvcOpHandler][multiInterface]")
 {
     auto fakeWlansvc = std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1, Mock::c_intf2}, std::vector{Mock::c_wpa2PskNetwork});
-    auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+    auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
 
     unsigned long signalQuality = 80;
     int8_t rssi = -60; // (rssi + 100) * 2 = signalQuality
@@ -851,40 +856,41 @@ TEST_CASE("Notifications for fake networks use FakeInterfaceGuid", "[wlansvcOpHa
 {
     auto fakeWlansvc = std::make_shared<Mock::WlanSvcFake>();
 
-    DOT11_MAC_ADDRESS bssid{0, 0, 0, 0, 0, 1};
-    auto origin = EventSource::Host;
-    auto guid = GUID{};
+    struct TestObserver: public ProxyWifiObserver
+    {
+        void OnGuestDisconnectionCompletion(OperationType, OperationStatus, const GUID& interfaceGuid, const DOT11_SSID&) noexcept override
+        {
+            guid = interfaceGuid;
+        }
+        void OnGuestConnectionCompletion(OperationType, OperationStatus, const GUID& interfaceGuid, const DOT11_SSID&, DOT11_AUTH_ALGORITHM) noexcept override
+        {
+            guid = interfaceGuid;
+        }
+        GUID guid{};
+    };
 
+    auto observer = std::make_shared<TestObserver>();
     auto opHandler = MakeUnitTestOperationHandler(
-        {[&](auto o, auto a) {
-             origin = o;
-             guid = a.interfaceGuid;
-         },
-         [&](auto o, auto a) {
-             origin = o;
-             guid = a.interfaceGuid;
-         },
-         {},
-         [&] {
-             return std::vector<WifiNetworkInfo>{{Mock::c_pizzaNetwork.network.dot11Ssid, bssid}};
-         }},
-        fakeWlansvc);
+        fakeWlansvc,
+        [&] {
+            DOT11_MAC_ADDRESS bssid{0, 0, 0, 0, 0, 1};
+            return std::vector<WifiNetworkInfo>{{Mock::c_pizzaNetwork.network.dot11Ssid, bssid}};
+        },
+        observer);
 
     auto connectRequest = MakeWpa2PskConnectRequest(Mock::c_pizzaNetwork.bss.ssid);
     auto connectResponse = opHandler->HandleConnectRequest(connectRequest);
-    CHECK(origin == EventSource::Guest);
-    CHECK(guid == FakeInterfaceGuid);
+    CHECK(observer->guid == FakeInterfaceGuid);
 
     auto disconnectRequest = MakeDisconnectRequest(1);
     auto disconnectResponse = opHandler->HandleDisconnectRequest(disconnectRequest);
-    CHECK(origin == EventSource::Guest);
-    CHECK(guid == FakeInterfaceGuid);
+    CHECK(observer->guid == FakeInterfaceGuid);
 }
 
 TEST_CASE("Handle interface arrival", "[wlansvcOpHandler][multiInterface]")
 {
     auto fakeWlansvc = std::make_shared<Mock::WlanSvcFake>();
-    auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+    auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
 
     fakeWlansvc->AddInterface(Mock::c_intf2);
     fakeWlansvc->AddNetwork(Mock::c_intf2, Mock::c_wpa2PskNetwork);
@@ -900,7 +906,7 @@ TEST_CASE("Handle interface arrival", "[wlansvcOpHandler][multiInterface]")
 TEST_CASE("Handle interface departure", "[wlansvcOpHandler][multiInterface]")
 {
     auto fakeWlansvc = std::make_shared<Mock::WlanSvcFake>(std::vector{Mock::c_intf1}, std::vector{Mock::c_wpa2PskNetwork});
-    auto opHandler = MakeUnitTestOperationHandler({}, fakeWlansvc);
+    auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc);
 
     fakeWlansvc->RemoveInterface(Mock::c_intf1);
     fakeWlansvc->WaitForNotifComplete();


### PR DESCRIPTION
### Goals

Add notifications when the guest request and complete a scan.
Refactor notifications to make them more consistent and avoid too many callbacks.

### Technical Details

Notification callbacks are now grouped in a `ProxyWifiObserver` object. Client can inherit from this object and override methods for the notification they need.

Host initiated event are behaving the same as before.
Guest initiated event are now causing two notification each, one when the request is received and one when the request is processed by the host, before sending an answer to the guest.
This make the extra callback `OnGuestConnectRequestProgress` redundant, so it can be deleted.

### Testing

Unit tests confirm notifications are sent as expected.

### Reviewer Focus

Does the API for notification seems complete, clear and understandable?

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formated with clang-format
- [x] Newly added code include doxygen-style comments
- [x] Unit tests are succeeding
