### PR TITLE
Add virtual destructor to ProxyWifiObserver

### DIFF
--- a/include/ProxyWifi/ProxyWifiService.hpp
+++ b/include/ProxyWifi/ProxyWifiService.hpp
@@ -99,6 +99,10 @@ enum class OperationType
 class ProxyWifiObserver
 {
 public:
+    virtual ~ProxyWifiObserver()
+    {
+    }
+
     struct ConnectRequestArgs {
         DOT11_SSID ssid;
     };

--- a/include/ProxyWifi/ProxyWifiService.hpp
+++ b/include/ProxyWifi/ProxyWifiService.hpp
@@ -99,9 +99,7 @@ enum class OperationType
 class ProxyWifiObserver
 {
 public:
-    virtual ~ProxyWifiObserver()
-    {
-    }
+    virtual ~ProxyWifiObserver() = default;
 
     struct ConnectRequestArgs {
         DOT11_SSID ssid;


### PR DESCRIPTION
### Goals

Fix a missing virtual destructor in `ProxyWifiObserver`

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formated with clang-format
- [x] Newly added code include doxygen-style comments
- [x] Unit tests are succeeding
