### PR TITLE
Fix static analysis warnings

### DIFF
--- a/cmdline/ProxyWifiCmd.cpp
+++ b/cmdline/ProxyWifiCmd.cpp
@@ -5,10 +5,7 @@
 #include "ProxyWifi/ProxyWifiService.hpp"
 
 #include <rpc.h>
-#include <winsock2.h>
-
-#include <stdio.h>
-#include <stdlib.h>
+#include <WinSock2.h>
 
 #include <charconv>
 #include <optional>
@@ -71,7 +68,7 @@ std::optional<ProxyWifiConfig> CreateProxyConfigFromArguments(int argc, const ch
     auto i = 1;
     while (i < argc)
     {
-        std::string_view option(argv[i]);
+        const std::string_view option(argv[i]);
         if (option == "-h")
         {
             print_help();
@@ -80,7 +77,7 @@ std::optional<ProxyWifiConfig> CreateProxyConfigFromArguments(int argc, const ch
         else if (option == "-p")
         {
             std::string_view value(argv[++i]);
-            auto res = std::from_chars(value.data(), value.data() + value.size(), manager.RequestResponsePort);
+            const auto res = std::from_chars(value.data(), value.data() + value.size(), manager.RequestResponsePort);
             if (res.ec == std::errc::invalid_argument)
             {
                 throw std::invalid_argument("Invalid port number");
@@ -89,7 +86,7 @@ std::optional<ProxyWifiConfig> CreateProxyConfigFromArguments(int argc, const ch
         else if (option == "-n")
         {
             std::string_view value(argv[++i]);
-            auto res = std::from_chars(value.data(), value.data() + value.size(), manager.NotificationPort);
+            const auto res = std::from_chars(value.data(), value.data() + value.size(), manager.NotificationPort);
             if (res.ec == std::errc::invalid_argument)
             {
                 throw std::invalid_argument("Invalid port number");
@@ -167,12 +164,12 @@ std::unique_ptr<ProxyWifiService> BuildProxyWifiService(const ProxyWifiConfig& s
     {
     case TransportType::HyperVSocket:
     {
-        ProxyWifiHyperVSettings proxySettings{settings.VmId, settings.RequestResponsePort, settings.NotificationPort, settings.Mode};
+        const ProxyWifiHyperVSettings proxySettings{settings.VmId, settings.RequestResponsePort, settings.NotificationPort, settings.Mode};
         return BuildProxyWifiService(proxySettings, {});
     }
     case TransportType::TcpSocket:
     {
-        ProxyWifiTcpSettings proxySettings{settings.ListenIp.value(), settings.RequestResponsePort, settings.NotificationPort, settings.Mode};
+        const ProxyWifiTcpSettings proxySettings{settings.ListenIp.value(), settings.RequestResponsePort, settings.NotificationPort, settings.Mode};
         return BuildProxyWifiService(proxySettings, {});
     }
     default:
@@ -216,12 +213,12 @@ try
     {
         std::cerr << "Invalid parameter: " << e.what() << std::endl;
         print_help();
-        exit(-1);
+        return -1;
     }
 
     if (!proxyConfig)
     {
-        exit(0);
+        return 0;
     }
 
     if (proxyConfig->UseTracelogging)
@@ -229,7 +226,7 @@ try
         Log::AddLogger(std::make_unique<Log::TraceLoggingLogger>());
     }
 
-    auto proxyService = BuildProxyWifiService(*proxyConfig);
+    const auto proxyService = BuildProxyWifiService(*proxyConfig);
     proxyService->Start();
 
     // Sleep until the program is interrupted with Ctrl-C
@@ -246,12 +243,12 @@ catch (const wil::ResultException& ex)
     }
     std::wcerr << std::endl;
 
-    std::exit(-1);
+    return -1;
 }
 catch (const std::exception& ex)
 {
     std::cerr << "Caught unhandled exception: " << ex.what() << std::endl;
-    std::exit(-1);
+    return -1;
 }
 catch (...)
 {

--- a/include/ProxyWifi/Logs.hpp
+++ b/include/ProxyWifi/Logs.hpp
@@ -20,7 +20,7 @@ class Logger
 {
 public:
     virtual void Log(Level level, const wchar_t* message) noexcept = 0;
-    virtual ~Logger(){};
+    virtual ~Logger() = default;
 };
 
 /// @brief Logger printing to the standard console output
@@ -46,9 +46,9 @@ namespace Details {
     {
     public:
         LogManager(const LogManager&) = delete;
-        LogManager(const LogManager&&) = delete;
+        LogManager(LogManager&&) = delete;
         LogManager& operator=(const LogManager&) = delete;
-        LogManager& operator=(const LogManager&&) = delete;
+        LogManager& operator=(LogManager&&) = delete;
 
         static LogManager& Get() noexcept
         {

--- a/include/ProxyWifi/ProxyWifiService.hpp
+++ b/include/ProxyWifi/ProxyWifiService.hpp
@@ -4,10 +4,9 @@
 
 #include <functional>
 #include <memory>
-#include <optional>
 #include <vector>
 
-#include <windows.h>
+#include <Windows.h>
 #include <windot11.h>
 #include <wlantypes.h>
 
@@ -195,6 +194,7 @@ struct ProxyWifiHyperVSettings
     /// @param guestVmId The vm id of the HyperV container guest from which to allow connections.
     /// @param requestResponsePort The HyperV socket port number for the request/response communication channel.
     /// @param notificationPort The HyperV socket port number for the notification communication channel.
+    /// @param mode The mode of operation used to emulate or virtualize Wifi
     ProxyWifiHyperVSettings(const GUID& guestVmId, unsigned short requestResponsePort, unsigned short notificationPort, OperationMode mode);
 
     /// @brief Construct a setting object to configure a new Wifi Proxy using an Hyper V transport
@@ -221,12 +221,12 @@ struct ProxyWifiTcpSettings
     /// @param listenIp The TCP/IP address for the proxy to listen for connection.
     /// @param requestResponsePort The TCP/IP port number for the request/response communication channel.
     /// @param notificationPort The TCP/IP port number for the notification communication channel.
-    /// @param mode The initial mode the proxy should start with
-    ProxyWifiTcpSettings(const std::string& listenIp, unsigned short requestResponsePort, unsigned short notificationPort, OperationMode mode);
+    /// @param mode The mode of operation used to emulate or virtualize Wifi
+    ProxyWifiTcpSettings(std::string listenIp, unsigned short requestResponsePort, unsigned short notificationPort, OperationMode mode);
 
     /// @brief Construct a setting object to configure a new Wifi Proxy using a Tcp transport
     /// @param listenIp The TCP/IP address for the proxy to listen for connection.
-    explicit ProxyWifiTcpSettings(const std::string& listenIp);
+    explicit ProxyWifiTcpSettings(std::string listenIp);
 
     /// @brief The TCP/IP port number for the request/response communication channel.
     unsigned short RequestResponsePort = RequestResponsePortDefault;

--- a/include/ProxyWifi/ProxyWifiService.hpp
+++ b/include/ProxyWifi/ProxyWifiService.hpp
@@ -99,6 +99,10 @@ enum class OperationType
 class ProxyWifiObserver
 {
 public:
+    virtual ~ProxyWifiObserver()
+    {
+    }
+
     struct ConnectRequestArgs {
         DOT11_SSID ssid;
     };

--- a/include/ProxyWifi/ProxyWifiService.hpp
+++ b/include/ProxyWifi/ProxyWifiService.hpp
@@ -99,9 +99,7 @@ enum class OperationType
 class ProxyWifiObserver
 {
 public:
-    virtual ~ProxyWifiObserver()
-    {
-    }
+    virtual ~ProxyWifiObserver() = default;
 
     struct ConnectRequestArgs {
         DOT11_SSID ssid;

--- a/lib/ClientWlanInterface.cpp
+++ b/lib/ClientWlanInterface.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#pragma once
-
 #include "ClientWlanInterface.hpp"
 
 #include "StringUtils.hpp"
@@ -11,7 +9,7 @@
 namespace ProxyWifi {
 
 ClientWlanInterface::ClientWlanInterface(const GUID& interfaceGuid, std::function<std::vector<WifiNetworkInfo>()> callback)
-    : m_interfaceGuid{interfaceGuid}, m_getClientBssCallback{callback}
+    : m_getClientBssCallback{std::move(callback)}, m_interfaceGuid{interfaceGuid}
 {
 }
 
@@ -28,7 +26,7 @@ const GUID& ClientWlanInterface::GetGuid() const noexcept
 std::optional<ConnectedNetwork> ClientWlanInterface::IsConnectedTo(const Ssid& requestedSsid) noexcept
 {
     const auto clientNetworks = GetBssFromClient();
-    auto network =
+    const auto network =
         std::find_if(clientNetworks.cbegin(), clientNetworks.cend(), [&](const auto& n) { return n.ssid == requestedSsid; });
 
     if (network == clientNetworks.cend())
@@ -47,7 +45,7 @@ std::optional<ConnectedNetwork> ClientWlanInterface::IsConnectedTo(const Ssid& r
 std::future<std::pair<WlanStatus, ConnectedNetwork>> ClientWlanInterface::Connect(const Ssid& requestedSsid, const Bssid&, const WlanSecurity&)
 {
     const auto clientNetworks = GetBssFromClient();
-    auto network =
+    const auto network =
         std::find_if(clientNetworks.cbegin(), clientNetworks.cend(), [&](const auto& n) { return n.ssid == requestedSsid; });
 
     std::promise<std::pair<WlanStatus, ConnectedNetwork>> promise;
@@ -91,7 +89,7 @@ std::future<std::vector<ScannedBss>> ClientWlanInterface::Scan(std::optional<con
 
         // Create a wpa2psk network with the requested SSID and BSSID
         FakeBss fakeBss;
-        fakeBss.capabilities = BssCapability::Ess | BssCapability::Privacy,
+        fakeBss.capabilities = BssCapability::Ess | BssCapability::Privacy;
         fakeBss.ssid = bss.ssid;
         fakeBss.bssid = toBssid(bss.bssid);
         fakeBss.akmSuites = {AkmSuite::Psk};

--- a/lib/ClientWlanInterface.cpp
+++ b/lib/ClientWlanInterface.cpp
@@ -27,7 +27,7 @@ std::optional<ConnectedNetwork> ClientWlanInterface::IsConnectedTo(const Ssid& r
 {
     const auto clientNetworks = GetBssFromClient();
     const auto network =
-        std::find_if(clientNetworks.cbegin(), clientNetworks.cend(), [&](const auto& n) { return n.ssid == requestedSsid; });
+        std::ranges::find_if(clientNetworks, [&](const auto& n) { return n.ssid == requestedSsid; });
 
     if (network == clientNetworks.cend())
     {
@@ -46,7 +46,7 @@ std::future<std::pair<WlanStatus, ConnectedNetwork>> ClientWlanInterface::Connec
 {
     const auto clientNetworks = GetBssFromClient();
     const auto network =
-        std::find_if(clientNetworks.cbegin(), clientNetworks.cend(), [&](const auto& n) { return n.ssid == requestedSsid; });
+        std::ranges::find_if(clientNetworks, [&](const auto& n) { return n.ssid == requestedSsid; });
 
     std::promise<std::pair<WlanStatus, ConnectedNetwork>> promise;
     if (network == clientNetworks.cend())

--- a/lib/ClientWlanInterface.hpp
+++ b/lib/ClientWlanInterface.hpp
@@ -5,7 +5,7 @@
 
 #include "WlanInterface.hpp"
 
-#include <windows.h>
+#include <Windows.h>
 
 #include <future>
 #include <optional>
@@ -30,7 +30,7 @@ public:
     std::future<std::vector<ScannedBss>> Scan(std::optional<const Ssid>& ssid) override;
 
 private:
-    inline std::vector<WifiNetworkInfo> GetBssFromClient()
+    inline std::vector<WifiNetworkInfo> GetBssFromClient() const
     {
         if (m_getClientBssCallback)
         {

--- a/lib/Connection.cpp
+++ b/lib/Connection.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-#include <stdio.h>
 
 #include <wil/result_macros.h>
 
@@ -10,8 +9,8 @@
 
 namespace ProxyWifi {
 
-Connection::Connection(std::shared_ptr<OperationHandler>& operations)
-    : m_operations(operations)
+Connection::Connection(std::shared_ptr<OperationHandler> operations)
+    : m_operations(std::move(operations))
 {
 }
 
@@ -51,7 +50,7 @@ void Connection::Run()
         {
         case WIFI_OP_SCAN_REQUEST:
         {
-            auto command = ScanRequest{std::move(request->body)};
+            const auto command = ScanRequest{std::move(request->body)};
             Log::Info(L"Received: %ws", command.Describe().c_str());
 
             auto response = m_operations->HandleScanRequest(command);
@@ -62,7 +61,7 @@ void Connection::Run()
         }
         case WIFI_OP_CONNECT_REQUEST:
         {
-            auto command = ConnectRequest{std::move(request->body)};
+            const auto command = ConnectRequest{std::move(request->body)};
 
             Log::Info(L"Received: %ws", command.Describe().c_str());
             auto response = m_operations->HandleConnectRequest(command);
@@ -74,7 +73,7 @@ void Connection::Run()
         }
         case WIFI_OP_DISCONNECT_REQUEST:
         {
-            auto command = DisconnectRequest{std::move(request->body)};
+            const auto command = DisconnectRequest{std::move(request->body)};
             Log::Info(L"Received: %ws", command.Describe().c_str());
 
             auto response = m_operations->HandleDisconnectRequest(command);
@@ -85,7 +84,6 @@ void Connection::Run()
         }
         default:
             THROW_WIN32_MSG(ERROR_INVALID_MESSAGE, "Ignoring unknown command ID: %d", request->hdr.operation);
-            break;
         }
 
         Log::Trace(
@@ -100,7 +98,7 @@ void Connection::Run()
     }
 }
 
-ConnectionSocket::ConnectionSocket(wil::unique_socket socket, std::shared_ptr<OperationHandler>& operations)
+ConnectionSocket::ConnectionSocket(wil::unique_socket socket, const std::shared_ptr<OperationHandler>& operations)
     : Connection(operations), m_socket(std::move(socket))
 {
 }

--- a/lib/Connection.hpp
+++ b/lib/Connection.hpp
@@ -2,13 +2,10 @@
 // Licensed under the MIT license.
 #pragma once
 
-#include <atomic>
-#include <functional>
 #include <memory>
 #include <optional>
-#include <shared_mutex>
 
-#include <winsock2.h>
+#include <WinSock2.h>
 #include <wil/resource.h>
 
 #include "Messages.hpp"
@@ -27,10 +24,10 @@ public:
     /// @brief Creates a new wifi proxy connection.
     ///
     /// @param operations The object used to handle protocol messages.
-    Connection(std::shared_ptr<OperationHandler>& operations);
+    Connection(std::shared_ptr<OperationHandler> operations);
 
     /// @brief Destroy the Connection object.
-    virtual ~Connection(){};
+    virtual ~Connection() = default;
 
     /// @brief Start accepting requests on this connection.
     ///
@@ -60,8 +57,9 @@ class ConnectionSocket : public Connection
 {
 public:
     /// @brief Create a new connection using a socket as the transport.
+    /// @param socket The socket used for the connection
     /// @param operations The object used to handle protocol messages.
-    ConnectionSocket(wil::unique_socket socket, std::shared_ptr<OperationHandler>& operations);
+    ConnectionSocket(wil::unique_socket socket, const std::shared_ptr<OperationHandler>& operations);
 
 private:
     /// @brief Sends a protocol message on the connection.

--- a/lib/Iee80211Utils.hpp
+++ b/lib/Iee80211Utils.hpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 #pragma once
 
-#include <windows.h>
+#include <Windows.h>
 #include <wlanapi.h>
 #include <wil/common.h>
 #include <gsl/span>
@@ -247,7 +247,7 @@ public:
         return m_ssid;
     }
 
-    const uint8_t size() const noexcept
+    uint8_t size() const noexcept
     {
         // `m_ssid.size()` <= c_max_ssid_length = 32 as a class invariant
         return static_cast<uint8_t>(m_ssid.size());

--- a/lib/Logs.cpp
+++ b/lib/Logs.cpp
@@ -10,7 +10,7 @@
 namespace ProxyWifi::Log {
 
 namespace {
-    static constexpr std::array levelNames = {"Error", "Info", "Trace", "Debug"};
+    constexpr std::array levelNames = {"Error", "Info", "Trace", "Debug"};
 
     constexpr const char* LevelToCStr(Level lvl) noexcept
     {

--- a/lib/LogsHelpers.hpp
+++ b/lib/LogsHelpers.hpp
@@ -9,7 +9,7 @@ namespace ProxyWifi {
 
 /// @brief Add a WIL failure callback for the current thread.
 /// This allows to log messages from WIL macro and exceptions
-auto SetThreadWilFailureLogger()
+inline auto SetThreadWilFailureLogger()
 {
     return wil::ThreadFailureCallback([](const wil::FailureInfo& failure) noexcept {
         constexpr std::size_t sizeOfLogMessageWithNul = 2048;

--- a/lib/Messages.cpp
+++ b/lib/Messages.cpp
@@ -8,7 +8,7 @@ namespace ProxyWifi {
 
 bool ScanResponseBuilder::IsBssAlreadyPresent(const Bssid& bssid)
 {
-    return std::find_if(m_bssList.cbegin(), m_bssList.cend(), [&](const auto& bss) { return bss.bssid == bssid; }) != m_bssList.cend();
+    return std::ranges::find_if(m_bssList, [&](const auto& bss) { return bss.bssid == bssid; }) != m_bssList.cend();
 }
 
 void ScanResponseBuilder::AddBss(ScannedBss bss)
@@ -36,8 +36,8 @@ ScanResponse ScanResponseBuilder::Build() const
         const auto& bss = m_bssList[i];
         scanResponse->bss[i] = proxy_wifi_bss{
             {}, bss.capabilities, bss.rssi, bss.beaconInterval, bss.channelCenterFreq, wil::safe_cast<uint32_t>(bss.ies.size()), {}};
-        std::copy(bss.bssid.begin(), bss.bssid.end(), scanResponse->bss[i].bssid);
-        std::copy(bss.ies.begin(), bss.ies.end(), nextIe.data());
+        std::ranges::copy(bss.bssid, scanResponse->bss[i].bssid);
+        std::ranges::copy(bss.ies, nextIe.data());
         scanResponse->bss[i].ie_offset =
             wil::safe_cast<uint32_t>(std::distance(reinterpret_cast<uint8_t*>(&scanResponse->bss[i]), nextIe.data()));
 

--- a/lib/Messages.cpp
+++ b/lib/Messages.cpp
@@ -20,7 +20,7 @@ void ScanResponseBuilder::AddBss(ScannedBss bss)
     m_bssList.push_back(std::move(bss));
 }
 
-ScanResponse ScanResponseBuilder::Build()
+ScanResponse ScanResponseBuilder::Build() const
 {
     auto allocSize = sizeof(proxy_wifi_scan_response) + m_bssList.size() * sizeof(proxy_wifi_bss);
     for (const auto& bss : m_bssList)
@@ -31,7 +31,7 @@ ScanResponse ScanResponseBuilder::Build()
     ScanResponse scanResponse{allocSize, m_bssList.size()};
 
     auto nextIe = scanResponse.getIes();
-    for (auto i = 0; i < m_bssList.size(); ++i)
+    for (auto i = 0u; i < m_bssList.size(); ++i)
     {
         const auto& bss = m_bssList[i];
         scanResponse->bss[i] = proxy_wifi_bss{

--- a/lib/Messages.hpp
+++ b/lib/Messages.hpp
@@ -5,14 +5,9 @@
 
 #pragma once
 
-
-#include <windows.h>
-#include <wlanapi.h>
-
 #include <array>
 #include <algorithm>
 #include <cstdint>
-#include <memory>
 #include <stdexcept>
 #include <string>
 #include <sstream>
@@ -166,7 +161,7 @@ public:
         return Message(Operation, std::move(buffer.m_buffer));
     }
 
-    const std::wstring Describe() const
+    std::wstring Describe() const
     {
         return GetProtocolMessageTypeName(Operation);
     }
@@ -183,7 +178,7 @@ public:
     {
     }
 
-    const std::wstring Describe() const
+    std::wstring Describe() const
     {
         std::wostringstream stream;
         stream << L"Connect request, Ssid: "
@@ -224,7 +219,7 @@ public:
         get()->session_id = sessionId;
     }
 
-    const std::wstring Describe() const
+    std::wstring Describe() const
     {
         return L"Connect response, Result code: " + std::to_wstring(get()->result_code) + L", Session id: " +
                std::to_wstring(get()->session_id) + L", BssId: " + BssidToString(get()->bssid);
@@ -239,7 +234,7 @@ public:
     {
     }
 
-    const std::wstring Describe() const
+    std::wstring Describe() const
     {
         return L"Disconnect request, Session id: " + std::to_wstring(get()->session_id);
     }
@@ -257,7 +252,7 @@ public:
     {
     }
 
-    const std::wstring Describe() const
+    std::wstring Describe() const
     {
         return L"Scan request, Target ssid: " +
                (get()->ssid_len == 0
@@ -282,7 +277,7 @@ public:
         return m_ies;
     }
 
-    const std::wstring Describe() const
+    std::wstring Describe() const
     {
         return L"Scan response, Number of reported Bss: " + std::to_wstring(get()->num_bss) + L", Total size " +
                std::to_wstring(get()->total_size) + L" bytes";
@@ -300,7 +295,7 @@ class ScanResponseBuilder
 {
 public:
     void AddBss(ScannedBss bss);
-    ScanResponse Build();
+    ScanResponse Build() const;
 
 private:
     bool IsBssAlreadyPresent(const Bssid& bssid);
@@ -315,7 +310,7 @@ public:
         get()->session_id = sessionId;
     }
 
-    const std::wstring Describe() const
+    std::wstring Describe() const
     {
         return L"Disconnect notification, Session id: " + std::to_wstring(get()->session_id);
     }
@@ -329,7 +324,7 @@ public:
         get()->signal = signal;
     }
 
-    const std::wstring Describe() const
+    std::wstring Describe() const
     {
         return L"Signal quality notification, Signal: " + std::to_wstring(get()->signal);
     }

--- a/lib/Networks.cpp
+++ b/lib/Networks.cpp
@@ -21,14 +21,14 @@ enum class Endianness
 /// @brief Append an unsigned integer to a vector as a list of bytes with specified endianness
 /// @tparam N The number of bytes to append to the vector
 /// @tparam E The endianness (Little = CPU order, Big = Network order)
-/// @example appendNetworkBytes<4, Endianness::Big>(vec, 0x000fac04) -> vec = {..., 0x00, 0x0f, 0xac, 0x04}
-template <size_t N, Endianness E, class T, class V, std::enable_if_t<std::is_integral<V>::value && !std::is_signed<V>::value, int> = 1>
+/// @example appendBytes<4, Endianness::Big>(vec, 0x000fac04) -> vec = {..., 0x00, 0x0f, 0xac, 0x04}
+template <size_t N, Endianness E, class T, class V, std::enable_if_t<std::is_integral_v<V> && !std::is_signed_v<V>, int> = 1>
 void appendBytes(std::vector<T>& vector, V value)
 {
     vector.reserve(vector.size() + N);
-    for (auto i = 0; i < N; ++i)
+    for (auto i = 0u; i < N; ++i)
     {
-        auto bitShift = 0;
+        auto bitShift = 0u;
         if constexpr (E == Endianness::Big)
         {
             bitShift = (N - 1 - i) * 8;
@@ -77,7 +77,7 @@ std::vector<uint8_t> FakeBss::BuildInformationElements() const
         // Warning: Assume all provided akm and cipher are compatibles
         constexpr auto rsnIeBaseSize = 12; // Version, Group cipher, Num ciphers, Num akms, capabilities
         constexpr auto suiteBlockSize = 4;
-        const uint8_t rsnIeSize = wil::safe_cast<uint8_t>(rsnIeBaseSize + (akmSuites.size() + cipherSuites.size()) * suiteBlockSize);
+        const auto rsnIeSize = wil::safe_cast<uint8_t>(rsnIeBaseSize + (akmSuites.size() + cipherSuites.size()) * suiteBlockSize);
 
         ies.insert(ies.end(), {WI_EnumValue(ElementId::Rsn), rsnIeSize});
 
@@ -119,7 +119,7 @@ ScannedBss::ScannedBss(const FakeBss& fakeBss)
 }
 
 ScannedBss::ScannedBss(Bssid bssid, Ssid ssid, uint16_t capabilities, int8_t rssi, uint32_t channelCenterFreq, uint16_t beaconInterval, std::vector<uint8_t> ies)
-    : bssid{std::move(bssid)}, ssid{std::move(ssid)}, capabilities{capabilities}, rssi{rssi}, channelCenterFreq{channelCenterFreq}, beaconInterval{beaconInterval}, ies{std::move(ies)}
+    : bssid{bssid}, ssid{std::move(ssid)}, capabilities{capabilities}, rssi{rssi}, channelCenterFreq{channelCenterFreq}, beaconInterval{beaconInterval}, ies{std::move(ies)}
 {
 }
 

--- a/lib/Networks.hpp
+++ b/lib/Networks.hpp
@@ -18,7 +18,7 @@ struct FakeBss
     int32_t rssi = -50;
     uint32_t channelCenterFreq = 2432000; // 2.4GHz by default
     uint16_t beaconInterval = 0;
-    Bssid bssid;
+    Bssid bssid{};
     Ssid ssid;
     std::vector<AkmSuite> akmSuites;
     std::vector<CipherSuite> cipherSuites;
@@ -39,7 +39,7 @@ struct ScannedBss
     explicit ScannedBss(const FakeBss& fakeBss);
     ScannedBss(Bssid bssid, Ssid ssid, uint16_t capabilities, int8_t rssi, uint32_t channelCenterFreq, uint16_t beaconInterval, std::vector<uint8_t> ies);
 
-    Bssid bssid;
+    Bssid bssid{};
     Ssid ssid;
     uint16_t capabilities = 0;
     int32_t rssi = -50;
@@ -51,8 +51,8 @@ struct ScannedBss
 struct ConnectedNetwork
 {
     Ssid ssid;
-    Bssid bssid;
-    DOT11_AUTH_ALGORITHM auth;
+    Bssid bssid{};
+    DOT11_AUTH_ALGORITHM auth = DOT11_AUTH_ALGO_80211_OPEN;
 };
 
 } // namespace ProxyWifi

--- a/lib/OperationHandler.cpp
+++ b/lib/OperationHandler.cpp
@@ -215,8 +215,7 @@ void OperationHandler::AddInterface(const std::function<std::unique_ptr<IWlanInt
     m_serializedRunner.Run([this, wlanInterfaceBuilder] {
         auto wlanInterface = wlanInterfaceBuilder();
         const auto& newGuid = wlanInterface->GetGuid();
-        auto alreadyPresent =
-            std::any_of(m_wlanInterfaces.begin(), m_wlanInterfaces.end(), [&](const auto& i) { return i->GetGuid() == newGuid; });
+        auto alreadyPresent = std::ranges::any_of(m_wlanInterfaces, [&](const auto& i) { return i->GetGuid() == newGuid; });
 
         if (alreadyPresent)
         {
@@ -392,9 +391,8 @@ DisconnectResponse OperationHandler::HandleDisconnectRequestSerialized(const Dis
         return DisconnectResponse{};
     };
 
-    const auto interfaceToDisconnect = std::find_if(m_wlanInterfaces.begin(), m_wlanInterfaces.end(), [&](const auto& i) {
-        return m_guestConnection->interfaceGuid == i->GetGuid();
-    });
+    const auto interfaceToDisconnect =
+        std::ranges::find_if(m_wlanInterfaces, [&](const auto& i) { return m_guestConnection->interfaceGuid == i->GetGuid(); });
 
     if (interfaceToDisconnect == m_wlanInterfaces.end())
     {

--- a/lib/OperationHandler.hpp
+++ b/lib/OperationHandler.hpp
@@ -2,16 +2,12 @@
 // Licensed under the MIT license.
 #pragma once
 
-#include <any>
-#include <chrono>
 #include <functional>
-#include <iterator>
 #include <memory>
 #include <shared_mutex>
 #include <variant>
 #include <vector>
 
-#include "Networks.hpp"
 #include "Messages.hpp"
 #include "WlanInterface.hpp"
 #include "WorkQueue.hpp"
@@ -27,13 +23,13 @@ public:
     OperationHandler(ProxyWifiObserver* pObserver, std::vector<std::unique_ptr<IWlanInterface>> wlanInterfaces)
         : m_pClientObserver{pObserver}, m_wlanInterfaces{std::move(wlanInterfaces)}
     {
-        for (auto& wlanIntf: m_wlanInterfaces)
+        for (const auto& wlanIntf: m_wlanInterfaces)
         {
             wlanIntf->SetNotificationHandler(this);
         }
     }
 
-    virtual ~OperationHandler()
+    ~OperationHandler() override
     {
         // First, destroy all interfaces so no notification will be queued on a destroyed workqueue
         m_wlanInterfaces.clear();
@@ -41,6 +37,11 @@ public:
         // Then cancel async works before the object destruction to ensure nothing reference `this`
         m_serializedRunner.Cancel();
     }
+
+    OperationHandler(const OperationHandler&) = delete;
+    OperationHandler(OperationHandler&&) = delete;
+    OperationHandler& operator=(const OperationHandler&) = delete;
+    OperationHandler& operator=(OperationHandler&&) = delete;
 
     /// @brief Add an interface to the operation handler
     /// Takes a builder function instead of the interface directly to create the interface in the work queue

--- a/lib/OperationHandlerBuilder.hpp
+++ b/lib/OperationHandlerBuilder.hpp
@@ -4,7 +4,7 @@
 
 #include <memory>
 
-#include <wil/result.h>
+#include <wil/result_macros.h>
 
 #include "ProxyWifi/Logs.hpp"
 #include "OperationHandler.hpp"

--- a/lib/ProxyWifiServiceImpl.cpp
+++ b/lib/ProxyWifiServiceImpl.cpp
@@ -89,7 +89,7 @@ ProxyWifiHyperVSettings::ProxyWifiHyperVSettings(const GUID& guestVmId, unsigned
     : 
       RequestResponsePort(requestResponsePort),
       NotificationPort(notificationPort),
-        GuestVmId(guestVmId),
+      GuestVmId(guestVmId),
       ProxyMode(mode)
 {
 }

--- a/lib/ProxyWifiServiceImpl.cpp
+++ b/lib/ProxyWifiServiceImpl.cpp
@@ -2,10 +2,9 @@
 // Licensed under the MIT license.
 #include <utility>
 
-#include <wil/result.h>
+#include <wil/result_macros.h>
 
 #include "ClientWlanInterface.hpp"
-#include "LogsHelpers.hpp"
 #include "OperationHandlerBuilder.hpp"
 #include "StringUtils.hpp"
 #include "ProxyWifiServiceImpl.hpp"
@@ -54,8 +53,8 @@ std::shared_ptr<OperationHandler> GetOperationHandler(
 } // namespace
 
 WifiNetworkInfo::WifiNetworkInfo(const DOT11_SSID& ssid, const DOT11_MAC_ADDRESS& bssid)
+    : ssid{ssid}
 {
-    this->ssid = ssid;
     memcpy_s(this->bssid, sizeof this->bssid, bssid, sizeof bssid);
 }
 
@@ -87,9 +86,10 @@ void ProxyWifiCommon::Stop()
 }
 
 ProxyWifiHyperVSettings::ProxyWifiHyperVSettings(const GUID& guestVmId, unsigned short requestResponsePort, unsigned short notificationPort, OperationMode mode)
-    : GuestVmId(guestVmId),
+    : 
       RequestResponsePort(requestResponsePort),
       NotificationPort(notificationPort),
+        GuestVmId(guestVmId),
       ProxyMode(mode)
 {
 }
@@ -115,16 +115,16 @@ const ProxyWifiHyperVSettings& ProxyWifiHyperV::Settings() const
     return m_settings;
 }
 
-ProxyWifiTcpSettings::ProxyWifiTcpSettings(const std::string& listenIp, unsigned short requestResponsePort, unsigned short notificationPort, OperationMode proxyMode)
-    : ListenIp(listenIp),
-      RequestResponsePort(requestResponsePort),
+ProxyWifiTcpSettings::ProxyWifiTcpSettings(std::string listenIp, unsigned short requestResponsePort, unsigned short notificationPort, OperationMode proxyMode)
+    : RequestResponsePort(requestResponsePort),
       NotificationPort(notificationPort),
+      ListenIp(std::move(listenIp)),
       ProxyMode(proxyMode)
 {
 }
 
-ProxyWifiTcpSettings::ProxyWifiTcpSettings(const std::string& listenIp)
-    : ListenIp(listenIp)
+ProxyWifiTcpSettings::ProxyWifiTcpSettings(std::string listenIp)
+    : ListenIp(std::move(listenIp))
 {
 }
 

--- a/lib/ProxyWifiServiceImpl.hpp
+++ b/lib/ProxyWifiServiceImpl.hpp
@@ -16,13 +16,18 @@ class ProxyWifiCommon: public ProxyWifiService
 {
 public:
     ProxyWifiCommon(OperationMode mode, FakeNetworkProvider fakeNetworkCallback, ProxyWifiObserver* pObserver);
-    virtual ~ProxyWifiCommon();
+    ~ProxyWifiCommon() override;
+
+    ProxyWifiCommon(const ProxyWifiCommon&) = delete;
+    ProxyWifiCommon& operator=(const ProxyWifiCommon&) = delete;
+    ProxyWifiCommon(ProxyWifiCommon&&) = delete;
+    ProxyWifiCommon& operator=(ProxyWifiCommon&&) = delete;
 
     /// @brief Start the proxy.
     ///
     /// This creates the transport and begins accepting connections on it. Until
     /// Start() is called, the proxy is inactive and does not accept connections.
-    void Start();
+    void Start() override;
 
     /// @brief Stop the proxy.
     ///
@@ -30,7 +35,7 @@ public:
     /// to the proxy and destroy the transport. Following execution of this call,
     /// the proxy will no longer accept new connections. It may be restarted
     /// using Start().
-    void Stop();
+    void Stop() override;
 
 protected:
     /// @brief Create a transport for the proxy.
@@ -75,6 +80,8 @@ class ProxyWifiHyperV : public ProxyWifiCommon
 public:
     /// @brief Construct a new Proxy Wifi HyperV object.
     /// @param settings The settings controlling operations of the proxy.
+    /// @param fakeNetworkCallback Function that the proxy will call when it needs a list of fake network to emulate
+    /// @param pObserver The handler for guest and host notifications
     explicit ProxyWifiHyperV(const ProxyWifiHyperVSettings& settings, FakeNetworkProvider fakeNetworkCallback, ProxyWifiObserver* pObserver);
 
     /// @brief Get HyperV specific proxy settings.
@@ -98,6 +105,8 @@ public:
     /// @brief Construct a new Proxy Wifi Tcp object.
     ///
     /// @param settings The settings controlling operations of the proxy.
+    /// @param fakeNetworkCallback Function that the proxy will call when it needs a list of fake network to emulate
+    /// @param pObserver The handler for guest and host notifications
     explicit ProxyWifiTcp(const ProxyWifiTcpSettings& settings, FakeNetworkProvider fakeNetworkCallback, ProxyWifiObserver* pObserver);
 
     /// @brief TCP specific proxy settings.

--- a/lib/RealWlanInterface.cpp
+++ b/lib/RealWlanInterface.cpp
@@ -17,7 +17,7 @@ namespace {
 bool IsBssSupported(const ScannedBss& bss, const std::vector<WLAN_AVAILABLE_NETWORK>& networks)
 {
     const auto matchingNetwork =
-        std::find_if(networks.cbegin(), networks.cend(), [&](const auto& n) { return bss.ssid == n.dot11Ssid; });
+        std::ranges::find_if(networks, [&](const auto& n) { return bss.ssid == n.dot11Ssid; });
 
     if (matchingNetwork == networks.cend())
     {

--- a/lib/RealWlanInterface.hpp
+++ b/lib/RealWlanInterface.hpp
@@ -3,17 +3,14 @@
 
 #pragma once
 
-#include <windows.h>
+#include <Windows.h>
 #include <wlanapi.h>
-
-#include <wil/resource.h>
 
 #include <future>
 #include <optional>
 
 #include "Networks.hpp"
 #include "Iee80211Utils.hpp"
-#include "ProxyWifi/ProxyWifiService.hpp"
 #include "WlanInterface.hpp"
 #include "WlanSvcWrapper.hpp"
 
@@ -24,8 +21,13 @@ class RealWlanInterface: public IWlanInterface
 {
 public:
     // Add notification handler parameter
-    RealWlanInterface(const std::shared_ptr<Wlansvc::WlanApiWrapper>& wlansvc, const GUID& interfaceGuid);
-    ~RealWlanInterface();
+    RealWlanInterface(std::shared_ptr<Wlansvc::WlanApiWrapper> wlansvc, const GUID& interfaceGuid);
+    ~RealWlanInterface() override;
+
+    RealWlanInterface(const RealWlanInterface&) = delete;
+    RealWlanInterface(RealWlanInterface&&) = delete;
+    RealWlanInterface& operator=(const RealWlanInterface&) = delete;
+    RealWlanInterface& operator=(RealWlanInterface&&) = delete;
 
     void SetNotificationHandler(INotificationHandler* handler) override;
 
@@ -42,7 +44,7 @@ private:
     void OnConnectComplete(const WLAN_CONNECTION_NOTIFICATION_DATA& data);
     void OnDisconnected(const WLAN_CONNECTION_NOTIFICATION_DATA& data);
     void OnScanComplete();
-    void OnSignalQualityChange(unsigned long signal);
+    void OnSignalQualityChange(unsigned long signal) const;
 
     const std::shared_ptr<Wlansvc::WlanApiWrapper> m_wlansvc;
     const GUID m_interfaceGuid;
@@ -56,7 +58,7 @@ private:
     std::vector<ScannedBss> m_cachedScannedBss;
     std::vector<WLAN_AVAILABLE_NETWORK> m_cachedScannedNetworks;
 
-    INotificationHandler* m_notifCallback;
+    INotificationHandler* m_notifCallback{};
 
     inline void NotifyHostConnection(const Ssid& ssid, DOT11_AUTH_ALGORITHM authAlgo) const
     {

--- a/lib/SocketHelpers.cpp
+++ b/lib/SocketHelpers.cpp
@@ -3,10 +3,8 @@
 
 #include "SocketHelpers.hpp"
 
-#include <mswsock.h>
+#include <MSWSock.h>
 
-#include <array>
-#include <cstdio>
 #include <memory>
 #include <gsl/span>
 
@@ -46,8 +44,7 @@ std::pair<wil::unique_socket, sockaddr_in> CreateTcpSocket(const IN_ADDR& listen
     }
 
     // Bind address to server socket.
-    sockaddr_in sockaddrIn;
-    memset(&sockaddrIn, 0, sizeof(sockaddrIn));
+    sockaddr_in sockaddrIn{};
     sockaddrIn.sin_family = AF_INET;
     sockaddrIn.sin_port = htons(port);
     sockaddrIn.sin_addr = listenIpAddr;
@@ -70,7 +67,7 @@ AcceptAsyncContext::~AcceptAsyncContext()
     }
 }
 
-AcceptAsyncContext AcceptAsyncContext::Accept(const wil::unique_socket& listenSocket, std::function<std::pair<wil::unique_socket, size_t>()> createSocket)
+AcceptAsyncContext AcceptAsyncContext::Accept(const wil::unique_socket& listenSocket, const std::function<std::pair<wil::unique_socket, size_t>()>& createSocket)
 {
     auto [acceptSocket, addrSize] = createSocket();
     if (!acceptSocket.is_valid())
@@ -101,7 +98,7 @@ AcceptAsyncContext AcceptAsyncContext::Accept(const wil::unique_socket& listenSo
     return AcceptAsyncContext(std::move(acceptSocket), std::move(acceptEvent), std::move(buffer), std::move(overlapped));
 }
 
-static bool ReceiveBytes(wil::unique_socket& socket, gsl::span<uint8_t> buffer)
+static bool ReceiveBytes(const wil::unique_socket& socket, gsl::span<uint8_t> buffer)
 {
     while (buffer.size_bytes() > 0)
     {
@@ -122,7 +119,7 @@ static bool ReceiveBytes(wil::unique_socket& socket, gsl::span<uint8_t> buffer)
     return true;
 }
 
-std::optional<Message> ReceiveProxyWifiMessage(wil::unique_socket& socket)
+std::optional<Message> ReceiveProxyWifiMessage(const wil::unique_socket& socket)
 {
     Message message;
     if (!ReceiveBytes(socket, {reinterpret_cast<uint8_t*>(&message.hdr), sizeof(message.hdr)}))

--- a/lib/SocketHelpers.hpp
+++ b/lib/SocketHelpers.hpp
@@ -7,8 +7,7 @@
 #include <stdexcept>
 #include <utility>
 
-#include <guiddef.h>
-#include <winsock2.h>
+#include <WinSock2.h>
 #include <hvsocket.h>
 #include <wil/resource.h>
 
@@ -71,9 +70,8 @@ class AcceptAsyncContext
 public:
     /// @brief Asynchronously accept a connection
     /// @param listenSocket The socket connection are listened on
-    /// @param onAccept Event that will be raised when a connection is accepted
     /// @return The socket the connection will be accepted on
-    static AcceptAsyncContext Accept(const wil::unique_socket& listenSocket, std::function<std::pair<wil::unique_socket, size_t>()> createSocket);
+    static AcceptAsyncContext Accept(const wil::unique_socket& listenSocket, const std::function<std::pair<wil::unique_socket, size_t>()>& createSocket);
 
     ~AcceptAsyncContext();
 
@@ -103,7 +101,7 @@ private:
 };
 
 /// @brief Helper function which receives a single protocol message on a generic socket.
-std::optional<Message> ReceiveProxyWifiMessage(wil::unique_socket& socket);
+std::optional<Message> ReceiveProxyWifiMessage(const wil::unique_socket& socket);
 
 /// @brief Helper function which sends a single protocol message on a generic socket.
 void SendProxyWifiMessage(wil::unique_socket& socket, const Message& message);

--- a/lib/TestWlanInterface.cpp
+++ b/lib/TestWlanInterface.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-#pragma once
-
 #include "TestWlanInterface.hpp"
 
 #include "LogsHelpers.hpp"
@@ -15,7 +13,7 @@ namespace ProxyWifi {
 
 namespace {
 
-DOT11_AUTH_ALGORITHM GetAuthAlgo(FakeBss bss)
+DOT11_AUTH_ALGORITHM GetAuthAlgo(const FakeBss& bss)
 {
     // The test interface support only open and wpa2psk networks
     return bss.akmSuites.empty() ? DOT11_AUTH_ALGO_80211_OPEN : DOT11_AUTH_ALGO_RSNA_PSK;
@@ -103,7 +101,7 @@ std::optional<ConnectedNetwork> TestWlanInterface::IsConnectedTo(const Ssid& req
 
 std::future<std::pair<WlanStatus, ConnectedNetwork>> TestWlanInterface::Connect(const Ssid& requestedSsid, const Bssid&, const WlanSecurity&)
 {
-    auto network = std::find_if(m_networks.cbegin(), m_networks.cend(), [&](const auto& n) { return n.ssid == requestedSsid; });
+    const auto network = std::find_if(m_networks.cbegin(), m_networks.cend(), [&](const auto& n) { return n.ssid == requestedSsid; });
 
     std::promise<std::pair<WlanStatus, ConnectedNetwork>> promise;
     if (network == m_networks.cend())
@@ -180,7 +178,7 @@ void TestWlanInterface::NotificationSender()
     for (;;)
     {
         std::cout << ">>> Enter a value to send a notification: ";
-        for (auto i = 0; i < notifications.size(); ++i)
+        for (auto i = 0u; i < notifications.size(); ++i)
         {
             std::cout << "<" << i << " -> " << notifications[i].second << "> ";
         }

--- a/lib/TestWlanInterface.cpp
+++ b/lib/TestWlanInterface.cpp
@@ -101,7 +101,7 @@ std::optional<ConnectedNetwork> TestWlanInterface::IsConnectedTo(const Ssid& req
 
 std::future<std::pair<WlanStatus, ConnectedNetwork>> TestWlanInterface::Connect(const Ssid& requestedSsid, const Bssid&, const WlanSecurity&)
 {
-    const auto network = std::find_if(m_networks.cbegin(), m_networks.cend(), [&](const auto& n) { return n.ssid == requestedSsid; });
+    const auto network = std::ranges::find_if(m_networks, [&](const auto& n) { return n.ssid == requestedSsid; });
 
     std::promise<std::pair<WlanStatus, ConnectedNetwork>> promise;
     if (network == m_networks.cend())

--- a/lib/TestWlanInterface.hpp
+++ b/lib/TestWlanInterface.hpp
@@ -5,7 +5,7 @@
 
 #include "WlanInterface.hpp"
 
-#include <windows.h>
+#include <Windows.h>
 
 #include <future>
 #include <optional>
@@ -38,7 +38,7 @@ private:
     std::mutex m_connectedNetworkMutex;
     std::optional<size_t> m_connectedNetwork;
 
-    INotificationHandler* m_notifCallback;
+    INotificationHandler* m_notifCallback{};
 
     inline void NotifyConnection(const Ssid& ssid, DOT11_AUTH_ALGORITHM authAlgo) const
     {

--- a/lib/Tracelog.hpp
+++ b/lib/Tracelog.hpp
@@ -22,12 +22,12 @@ class TraceProvider : public wil::TraceLoggingProvider
         TraceProvider,
         "Microsoft.WslCore.ProxyWifi",
         // 872a70db-e765-45e5-9141-4b35732837b6
-        (0x872a70db, 0xe765, 0x45e5, 0x91, 0x41, 0x4b, 0x35, 0x73, 0x28, 0x37, 0xb6));
+        (0x872a70db, 0xe765, 0x45e5, 0x91, 0x41, 0x4b, 0x35, 0x73, 0x28, 0x37, 0xb6))
 
-    DEFINE_TRACELOGGING_EVENT_STRING(Debug, Log, TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
-    DEFINE_TRACELOGGING_EVENT_STRING(Trace, Log, TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE));
-    DEFINE_TRACELOGGING_EVENT_STRING(Info, Log, TraceLoggingLevel(WINEVENT_LEVEL_INFO));
-    DEFINE_TRACELOGGING_EVENT_STRING(Error, Log, TraceLoggingLevel(WINEVENT_LEVEL_ERROR));
+    DEFINE_TRACELOGGING_EVENT_STRING(Debug, Log, TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE))
+    DEFINE_TRACELOGGING_EVENT_STRING(Trace, Log, TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE))
+    DEFINE_TRACELOGGING_EVENT_STRING(Info, Log, TraceLoggingLevel(WINEVENT_LEVEL_INFO))
+    DEFINE_TRACELOGGING_EVENT_STRING(Error, Log, TraceLoggingLevel(WINEVENT_LEVEL_ERROR))
 };
 
 } // namespace ProxyWifi::Log

--- a/lib/Transport.hpp
+++ b/lib/Transport.hpp
@@ -4,12 +4,10 @@
 
 #include <functional>
 #include <memory>
-#include <mutex>
-#include <stdexcept>
 #include <string>
 #include <utility>
 
-#include <winsock2.h>
+#include <WinSock2.h>
 
 #include <wil/resource.h>
 
@@ -31,6 +29,11 @@ public:
     /// @param requestResponsePort The request/response port to bind to.
     /// @param notificationPort The notification port to connect to.
     Transport(std::shared_ptr<OperationHandler>& operationHandler, unsigned short requestResponsePort, unsigned short notificationPort);
+
+    Transport(const Transport&) = delete;
+    Transport(Transport&&) = delete;
+    Transport& operator=(const Transport&) = delete;
+    Transport& operator=(Transport&&) = delete;
 
     /// @brief Destroy the Wifi Proxy Transport Socket object.
     virtual ~Transport();
@@ -89,7 +92,7 @@ public:
     /// @param notificationPort The HyperV socket port for the notification communication channel.
     /// @param guestVmId The vm if for which the transport should be restricted to.
     HyperVTransport(
-        std::shared_ptr<OperationHandler>& operationHandler, unsigned short requestResponsePort, unsigned short notificationPort, const GUID guestVmId);
+        std::shared_ptr<OperationHandler>& operationHandler, unsigned short requestResponsePort, unsigned short notificationPort, const GUID& guestVmId);
 
 private:
     wil::unique_socket CreateListenSocket() override;
@@ -122,7 +125,7 @@ private:
 
 private:
     const std::string m_listenIp;
-    IN_ADDR m_listenIpAddr;
+    IN_ADDR m_listenIpAddr{};
 };
 
 } // namespace ProxyWifi

--- a/lib/WlanInterface.hpp
+++ b/lib/WlanInterface.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <windows.h>
+#include <Windows.h>
 #include <wlantypes.h>
 
 #include <future>
@@ -12,7 +12,6 @@
 
 #include "Networks.hpp"
 #include "Iee80211Utils.hpp"
-#include "ProxyWifi/ProxyWifiService.hpp"
 
 namespace ProxyWifi {
 
@@ -20,7 +19,7 @@ namespace ProxyWifi {
 class INotificationHandler
 {
 public:
-    virtual ~INotificationHandler() {}
+    virtual ~INotificationHandler() = default;
 
     /// @brief Must be called by the interfaces when they connect to a network
     virtual void OnHostConnection(const GUID& interfaceGuid, const Ssid& ssid, DOT11_AUTH_ALGORITHM authAlgo) = 0;
@@ -37,7 +36,7 @@ public:
 class IWlanInterface
 {
 public:
-    virtual ~IWlanInterface() {};
+    virtual ~IWlanInterface() = default;
 
     /// @brief Allows to provide the callback the interface will call on specific events
     virtual void SetNotificationHandler(INotificationHandler* notificationHandler) = 0;

--- a/lib/WlanSvcHelpers.cpp
+++ b/lib/WlanSvcHelpers.cpp
@@ -61,7 +61,7 @@ static constexpr std::array MsmNotificationCodeStrings = {
     /* wlan_notification_msm_link_degraded                 */ "linkDegraded",
     /* wlan_notification_msm_link_improved                 */ "linkImproved"};
 
-inline const std::string AcmNotificationCodeToString(const WLAN_NOTIFICATION_ACM& acm)
+inline std::string AcmNotificationCodeToString(const WLAN_NOTIFICATION_ACM& acm)
 {
     if (acm <= wlan_notification_acm_start || acm >= wlan_notification_acm_end)
         THROW_WIN32_MSG(ERROR_INVALID_PARAMETER, "invalid WLAN_NOTIFICATION_ACM value (%d)", acm);
@@ -69,7 +69,7 @@ inline const std::string AcmNotificationCodeToString(const WLAN_NOTIFICATION_ACM
     return AcmNotificationCodeStrings[acm - 1];
 }
 
-inline const std::string MsmNotificationCodeToString(const WLAN_NOTIFICATION_MSM& msm)
+inline std::string MsmNotificationCodeToString(const WLAN_NOTIFICATION_MSM& msm)
 {
     if (msm <= wlan_notification_msm_start || msm >= wlan_notification_msm_end)
         THROW_WIN32_MSG(ERROR_INVALID_PARAMETER, "invalid WLAN_NOTIFICATION_MSM value (%d)", msm);
@@ -247,7 +247,7 @@ std::wstring ProfileNameFromSSID(const Ssid& ssid)
     constexpr auto c_defaultProfileName = L"ProxyWifi Network";
 
     std::array<wchar_t, WLAN_MAX_NAME_LENGTH> profileName{WLAN_MAX_NAME_LENGTH, L'\0'};
-    auto retValue = MultiByteToWideChar(
+    const auto retValue = MultiByteToWideChar(
         CP_UTF8,
         MB_ERR_INVALID_CHARS,
         reinterpret_cast<const char*>(ssid.value().data()),
@@ -375,7 +375,7 @@ DOT11_AUTH_CIPHER_PAIR DetermineAuthCipherPair(const WlanSecurity& secInfo)
 {
     const auto auth = DetermineAuth(secInfo.auth, secInfo.wpaVersion, secInfo.akmSuites);
 
-    auto candidateCiphers = ConvertCipherSuites(secInfo.cipherSuites);
+    const auto candidateCiphers = ConvertCipherSuites(secInfo.cipherSuites);
     for (auto cipher: candidateCiphers)
     {
         auto pair = std::make_pair(auth, cipher);

--- a/lib/WlanSvcHelpers.cpp
+++ b/lib/WlanSvcHelpers.cpp
@@ -318,7 +318,7 @@ bool IsAuthCipherPairSupported(const std::pair<DOT11_AUTH_ALGORITHM, DOT11_CIPHE
         std::make_pair(DOT11_AUTH_ALGO_RSNA_PSK, DOT11_CIPHER_ALGO_CCMP),
         std::make_pair(DOT11_AUTH_ALGO_RSNA_PSK, DOT11_CIPHER_ALGO_GCMP)};
 
-    return std::find(supportedAuthCiphers.cbegin(), supportedAuthCiphers.cend(), authCipher) != supportedAuthCiphers.cend();
+    return std::ranges::find(supportedAuthCiphers, authCipher) != supportedAuthCiphers.cend();
 }
 
 namespace {
@@ -329,7 +329,7 @@ std::vector<DOT11_CIPHER_ALGORITHM> ConvertCipherSuites(gsl::span<const CipherSu
         return {DOT11_CIPHER_ALGO_NONE};
     }
     std::vector<DOT11_CIPHER_ALGORITHM> r;
-    std::transform(ciphers.begin(), ciphers.end(), std::back_inserter(r), CipherSuiteToWindowsEnum);
+    std::ranges::transform(ciphers, std::back_inserter(r), CipherSuiteToWindowsEnum);
     return r;
 }
 
@@ -344,7 +344,7 @@ constexpr DOT11_AUTH_ALGORITHM DetermineAuth(AuthAlgo auth, uint8_t wpaVersion, 
         else if (wpaVersion == 2)
         {
             constexpr std::array wpa2akms{AkmSuite::Psk, AkmSuite::PskSha256, AkmSuite::PskSha384, AkmSuite::FtPsk, AkmSuite::FtPskSha384};
-            if (std::find_first_of(akms.begin(), akms.end(), wpa2akms.begin(), wpa2akms.end()) == akms.end())
+            if (std::ranges::find_first_of(akms, wpa2akms) == akms.end())
             {
                 throw std::invalid_argument("Unsupported authentication algorithm: Open/Wpa2, but no PSK AKM");
             }
@@ -357,7 +357,7 @@ constexpr DOT11_AUTH_ALGORITHM DetermineAuth(AuthAlgo auth, uint8_t wpaVersion, 
     }
     else if (auth == AuthAlgo::Sae)
     {
-        if (std::find(akms.begin(), akms.end(), AkmSuite::Sae) == akms.end())
+        if (std::ranges::find(akms, AkmSuite::Sae) == akms.end())
         {
             throw std::invalid_argument("Unsupported SAE authentication algorithm: No SAE AKM");
         }

--- a/lib/WlanSvcHelpers.hpp
+++ b/lib/WlanSvcHelpers.hpp
@@ -7,7 +7,7 @@
 #include <utility>
 #include <string>
 
-#include <windows.h>
+#include <Windows.h>
 #include <wlanapi.h>
 #include <wlantypes.h>
 

--- a/lib/WlanSvcWrapper.cpp
+++ b/lib/WlanSvcWrapper.cpp
@@ -35,7 +35,7 @@ try
 {
     SetThreadWilFailureLogger();
     THROW_IF_NULL_ALLOC(pContext);
-    auto& wlansvc = *reinterpret_cast<WlanApiWrapperImpl*>(pContext);
+    auto& wlansvc = *static_cast<WlanApiWrapperImpl*>(pContext);
     wlansvc.HandleWlansvcNotification(pNotification);
 }
 CATCH_LOG()
@@ -170,7 +170,7 @@ std::vector<ScannedBss> WlanApiWrapperImpl::GetScannedBssList(const GUID& interf
     std::vector<ScannedBss> scannedBss;
     for (const auto& bss : wil::make_range(pBssList->wlanBssEntries, pBssList->dwNumberOfItems))
     {
-        auto ieStart = reinterpret_cast<const uint8_t*>(&bss) + bss.ulIeOffset;
+        const auto ieStart = reinterpret_cast<const uint8_t*>(&bss) + bss.ulIeOffset;
         scannedBss.emplace_back(
             toBssid(bss.dot11Bssid),
             bss.dot11Ssid,

--- a/lib/WlanSvcWrapper.hpp
+++ b/lib/WlanSvcWrapper.hpp
@@ -2,12 +2,11 @@
 // Licensed under the MIT license.
 #pragma once
 
-#include <windows.h>
+#include <Windows.h>
 #include <wlanapi.h>
 #include <wil/resource.h>
 
 #include <functional>
-#include <mutex>
 #include <optional>
 #include <unordered_map>
 #include <vector>
@@ -66,6 +65,11 @@ public:
     WlanApiWrapperImpl();
     ~WlanApiWrapperImpl() override;
 
+    WlanApiWrapperImpl(const WlanApiWrapperImpl&) = delete;
+    WlanApiWrapperImpl(WlanApiWrapperImpl&&) = delete;
+    WlanApiWrapperImpl& operator=(const WlanApiWrapperImpl&) = delete;
+    WlanApiWrapperImpl& operator=(WlanApiWrapperImpl&&) = delete;
+
     std::vector<GUID> EnumerateInterfaces() override;
     void Subscribe(const GUID& interfaceGuid, std::function<void(const WLAN_NOTIFICATION_DATA&)> callback) override;
     void Unsubscribe(const GUID& interfaceGuid) override;
@@ -81,7 +85,7 @@ private:
     void HandleWlansvcNotification(PWLAN_NOTIFICATION_DATA pNotification);
 
 private:
-    HANDLE m_wlanHandle;
+    HANDLE m_wlanHandle{};
     wil::srwlock m_callbacksLock;
     std::unordered_map<GUID, std::function<void(const WLAN_NOTIFICATION_DATA&)>> m_callbacks;
 

--- a/lib/WlansvcOperationHandler.hpp
+++ b/lib/WlansvcOperationHandler.hpp
@@ -50,13 +50,18 @@ public:
         });
     }
 
-    virtual ~WlansvcOperationHandler()
+    ~WlansvcOperationHandler() override
     {
         if (m_wlansvc)
         {
             m_wlansvc->Unsubscribe(GUID{});
         }
     }
+
+    WlansvcOperationHandler(const WlansvcOperationHandler&) = delete;
+    WlansvcOperationHandler(WlansvcOperationHandler&&) = delete;
+    WlansvcOperationHandler& operator=(const WlansvcOperationHandler&) = delete;
+    WlansvcOperationHandler& operator= (WlansvcOperationHandler&&) = delete;
 
 private:
     std::shared_ptr<Wlansvc::WlanApiWrapper> m_wlansvc;

--- a/test/TestInit.cpp
+++ b/test/TestInit.cpp
@@ -23,6 +23,6 @@ TEST_CASE("Creating a WlanApiWrapper doesn't cause a crash", "[init]")
 
 TEST_CASE("WlanApiWrapper is optionnal to create an OperationHandler", "[init]")
 {
-    auto opHandler = MakeWlansvcOperationHandler(std::shared_ptr<Wlansvc::WlanApiWrapper>{}, {}, {});
+    const auto opHandler = MakeWlansvcOperationHandler(std::shared_ptr<Wlansvc::WlanApiWrapper>{}, {}, {});
     CHECK(opHandler);
 }

--- a/test/TestOpHandler.cpp
+++ b/test/TestOpHandler.cpp
@@ -38,7 +38,7 @@ ConnectRequest MakeWpa2PskConnectRequest(const Ssid& ssid)
     connectRequest->pairwise_cipher_suites[0] = WI_EnumValue(CipherSuite::Ccmp);
     connectRequest->group_cipher_suite = WI_EnumValue(CipherSuite::Ccmp);
     connectRequest->key_len = wil::safe_cast<uint8_t>(key.size());
-    std::copy(key.begin(), key.end(), connectRequest->key);
+    std::ranges::copy(key, connectRequest->key);
 
     return ConnectRequest{std::move(body)};
 }
@@ -198,7 +198,7 @@ TEST_CASE("Handle scan on multiple interfaces", "[wlansvcOpHandler][multiInterfa
 
         Ssid ssid{"ethernet"};
         DOT11_MAC_ADDRESS bssid{};
-        std::copy(Mock::c_wpa2PskNetwork.bss.bssid.cbegin(), Mock::c_wpa2PskNetwork.bss.bssid.cend(), bssid);
+        std::ranges::copy(Mock::c_wpa2PskNetwork.bss.bssid, bssid);
 
         auto opHandler = MakeUnitTestOperationHandler(fakeWlansvc, [&] {
             return std::vector<WifiNetworkInfo>{{static_cast<DOT11_SSID>(ssid), bssid}};

--- a/test/TestUtils.cpp
+++ b/test/TestUtils.cpp
@@ -21,7 +21,7 @@ TEST_CASE("HexStringToByteBuffer parse correctly", "[stringUtils]")
 
 TEST_CASE("GuidToString format correctly", "[stringUtils]")
 {
-    GUID guid{0xfef2f808, 0xf267, 0x4728, {0xa0, 0xc5, 0x0a, 0x62, 0x40, 0xd0, 0x1b, 0x33}};
+    constexpr GUID guid{0xfef2f808, 0xf267, 0x4728, {0xa0, 0xc5, 0x0a, 0x62, 0x40, 0xd0, 0x1b, 0x33}};
     CHECK(GuidToString(guid) == std::wstring(L"{FEF2F808-F267-4728-A0C5-0A6240D01B33}"));
 }
 

--- a/test/WlansvcMock.hpp
+++ b/test/WlansvcMock.hpp
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+#pragma once
+
 #include <catch2/catch.hpp>
-#include "WlansvcWrapper.hpp"
+#include "WlanSvcWrapper.hpp"
 
 #include "Iee80211Utils.hpp"
 #include "StringUtils.hpp"
@@ -158,8 +160,7 @@ struct WlanSvcFake : public ProxyWifi::Wlansvc::WlanApiWrapper
 {
     WlanSvcFake() = default;
 
-    WlanSvcFake(std::vector<GUID> interfaces, std::vector<Network> visibleNetworks = {})
-        : m_interfaces{}
+    WlanSvcFake(const std::vector<GUID>& interfaces, const std::vector<Network>& visibleNetworks = {})
     {
         for (const auto& guid : interfaces)
         {
@@ -167,7 +168,12 @@ struct WlanSvcFake : public ProxyWifi::Wlansvc::WlanApiWrapper
         }
     }
 
-    ~WlanSvcFake()
+    WlanSvcFake(const WlanSvcFake&) = delete;
+    WlanSvcFake(WlanSvcFake&&) = delete;
+    WlanSvcFake& operator=(const WlanSvcFake&) = delete;
+    WlanSvcFake& operator=(WlanSvcFake&&) = delete;
+
+    ~WlanSvcFake() override
     {
         WaitForNotifComplete();
     }
@@ -274,7 +280,7 @@ struct WlanSvcFake : public ProxyWifi::Wlansvc::WlanApiWrapper
 
     void RemoveInterface(const GUID& interfaceGuid)
     {
-        auto it = m_interfaces.find(interfaceGuid);
+        const auto it = m_interfaces.find(interfaceGuid);
         if (it != m_interfaces.end())
         {
             m_interfaces.erase(it);
@@ -288,7 +294,7 @@ struct WlanSvcFake : public ProxyWifi::Wlansvc::WlanApiWrapper
     void ConnectHost(const GUID& interfaceGuid, const ProxyWifi::Ssid& ssid)
     {
         const auto& networks = m_interfaces.at(interfaceGuid).m_visibleNetworks;
-        auto network = std::find_if(networks.begin(), networks.end(), [&](const auto& e) { return ssid == e.bss.ssid; });
+        const auto network = std::find_if(networks.begin(), networks.end(), [&](const auto& e) { return ssid == e.bss.ssid; });
 
         if (network != networks.end())
         {
@@ -300,7 +306,7 @@ struct WlanSvcFake : public ProxyWifi::Wlansvc::WlanApiWrapper
         }
 
         // Send a notification to annonce the connection completion
-        auto notifCallback = m_notifCallbacks.find(interfaceGuid);
+        const auto notifCallback = m_notifCallbacks.find(interfaceGuid);
         if (notifCallback != m_notifCallbacks.end())
         {
             auto r = m_interfaces.at(interfaceGuid).m_connectedBss ? WLAN_REASON_CODE_SUCCESS : WLAN_REASON_CODE_UNKNOWN;
@@ -368,9 +374,9 @@ private:
 
         m_notifThread = std::thread([this, intfGuid, notifBuilder = std::move(notifBuilder)] {
             auto lock = m_notifLock.lock_shared();
-            auto callback = m_notifCallbacks.find(intfGuid);
+            const auto callback = m_notifCallbacks.find(intfGuid);
             // Null guid subscription get all the notifications
-            auto allIntfCallback = m_notifCallbacks.find(GUID{});
+            const auto allIntfCallback = m_notifCallbacks.find(GUID{});
             notifBuilder([&](const auto& n) {
                 if (callback != m_notifCallbacks.end())
                 {
@@ -390,7 +396,7 @@ private:
         std::vector<Network> m_visibleNetworks;
         std::optional<Network> m_connectedBss;
     };
-    std::unordered_map<GUID, WlanInterface> m_interfaces = {};
+    std::unordered_map<GUID, WlanInterface> m_interfaces;
 
     wil::srwlock m_notifLock;
     std::unordered_map<GUID, std::function<void(const WLAN_NOTIFICATION_DATA&)>> m_notifCallbacks;

--- a/test/WlansvcMock.hpp
+++ b/test/WlansvcMock.hpp
@@ -215,7 +215,7 @@ struct WlanSvcFake : public ProxyWifi::Wlansvc::WlanApiWrapper
             WLAN_CONNECTION_ATTRIBUTES r{};
             r.isState = connectedBss ? wlan_interface_state_connected : wlan_interface_state_disconnected;
             r.wlanAssociationAttributes.dot11Ssid = connectedBss->bss.ssid;
-            std::copy(connectedBss->bss.bssid.cbegin(), connectedBss->bss.bssid.cend(), r.wlanAssociationAttributes.dot11Bssid);
+            std::ranges::copy(connectedBss->bss.bssid, r.wlanAssociationAttributes.dot11Bssid);
             r.wlanSecurityAttributes.dot11AuthAlgorithm = connectedBss->network.dot11DefaultAuthAlgorithm;
             r.wlanSecurityAttributes.dot11CipherAlgorithm = connectedBss->network.dot11DefaultCipherAlgorithm;
             return r;
@@ -255,7 +255,7 @@ struct WlanSvcFake : public ProxyWifi::Wlansvc::WlanApiWrapper
         const auto& networks = m_interfaces.at(interfaceGuid).m_visibleNetworks;
 
         std::vector<ProxyWifi::ScannedBss> r;
-        std::transform(networks.cbegin(), networks.cend(), std::back_inserter(r), [](const auto& n) { return n.bss; });
+        std::ranges::transform(networks, std::back_inserter(r), [](const auto& n) { return n.bss; });
         return r;
     }
 
@@ -264,7 +264,7 @@ struct WlanSvcFake : public ProxyWifi::Wlansvc::WlanApiWrapper
         const auto& networks = m_interfaces.at(interfaceGuid).m_visibleNetworks;
 
         std::vector<WLAN_AVAILABLE_NETWORK> r;
-        std::transform(networks.cbegin(), networks.cend(), std::back_inserter(r), [](const auto& n) { return n.network; });
+        std::ranges::transform(networks, std::back_inserter(r), [](const auto& n) { return n.network; });
         return r;
     }
 
@@ -294,7 +294,7 @@ struct WlanSvcFake : public ProxyWifi::Wlansvc::WlanApiWrapper
     void ConnectHost(const GUID& interfaceGuid, const ProxyWifi::Ssid& ssid)
     {
         const auto& networks = m_interfaces.at(interfaceGuid).m_visibleNetworks;
-        const auto network = std::find_if(networks.begin(), networks.end(), [&](const auto& e) { return ssid == e.bss.ssid; });
+        const auto network = std::ranges::find_if(networks, [&](const auto& e) { return ssid == e.bss.ssid; });
 
         if (network != networks.end())
         {

--- a/util/DynamicFunction.hpp
+++ b/util/DynamicFunction.hpp
@@ -40,6 +40,6 @@ private:
     }
 
 private:
-    std::function<R(Args...)> m_function;
     wil::unique_hmodule m_module;
+    std::function<R(Args...)> m_function;
 };

--- a/util/GuidUtils.hpp
+++ b/util/GuidUtils.hpp
@@ -6,9 +6,8 @@
 #include <rpc.h>
 #include <guiddef.h>
 
-namespace std {
 template <>
-struct hash<GUID>
+struct std::hash<GUID>
 {
     std::size_t operator()(const GUID& guid) const noexcept
     {
@@ -16,7 +15,6 @@ struct hash<GUID>
         return ::UuidHash(&const_cast<GUID&>(guid), &status);
     }
 };
-} // namespace std
 
 inline bool operator<(const GUID& lhs, const GUID& rhs)
 {

--- a/util/StringUtils.hpp
+++ b/util/StringUtils.hpp
@@ -9,7 +9,7 @@
 #include <gsl/span>
 #include <sstream>
 
-#include <windows.h>
+#include <Windows.h>
 #include <wil/win32_helpers.h>
 
 /// @brief Allow to convert a buffer of bytes as a string of hexadecimal two-digit values
@@ -40,7 +40,7 @@ inline static std::vector<uint8_t> HexStringToByteBuffer(const std::wstring_view
     }
 
     std::vector<uint8_t> byteBuffer;
-    for (auto i = 0; i < s.size(); i += 2)
+    for (auto i = 0u; i < s.size(); i += 2)
     {
         std::wstring t{s.substr(i, 2)};
         byteBuffer.push_back(static_cast<uint8_t>(std::stoul(t, nullptr, 16)));
@@ -80,7 +80,7 @@ inline static std::wstring SsidToLogString(const gsl::span<const uint8_t> ssid)
 {
     std::wostringstream stream;
     stream << L"'" << std::wstring{ssid.begin(), ssid.end()} << L"' [";
-    for (auto b : ssid)
+    for (const auto b : ssid)
     {
         stream << std::isprint(b) ? b : '?';
     }

--- a/util/WorkQueue.hpp
+++ b/util/WorkQueue.hpp
@@ -4,8 +4,8 @@
 
 #include <Windows.h>
 #include <wil/resource.h>
-#include <wil/result.h>
 
+#include <any>
 #include <deque>
 #include <optional>
 
@@ -15,9 +15,9 @@ template<class WorkItem, int minThread, int maxThread, std::enable_if_t<std::is_
 class WorkQueue
 {
 public:
-    WorkQueue() : m_threadPool(minThread, maxThread)
+    WorkQueue()
+    : m_threadPool(minThread, maxThread), m_threadPoolWork{m_threadPool.CreateWork(WorkCallback, this)}
     {
-        m_threadPoolWork = m_threadPool.CreateWork(WorkCallback, this);
     }
 
     ~WorkQueue() noexcept
@@ -81,7 +81,7 @@ private:
             wil::unique_threadpool_work work(::CreateThreadpoolWork(callback, context, &m_threadpoolEnv));
             THROW_LAST_ERROR_IF_NULL(work.get());
             return work;
-        };
+        }
     };
 
     static void CALLBACK WorkCallback(_Inout_ PTP_CALLBACK_INSTANCE, _In_ void* context, _Inout_ PTP_WORK) noexcept


### PR DESCRIPTION
### Goals

Fix numerous warnings reported by running static analysis tools (resharper / clang-tidy).

### Technical Details

There are no functional changes.

Most fixes are about:

- deleting copy/move constructor and assignment operators
- fixing the initialization order of class members
- passing argument by copy + move or reference when appropriate
- adding `const` where possible
- as a bonus, use range algorithms

### Testing

Unit tests succeeds.

### Future Work

I am thinking about trying to integrate some of these checks in the pipeline.

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formated with clang-format
- [x] Newly added code include doxygen-style comments
- [x] Unit tests are succeeding
