### PR TITLE
Fix dynamicFunction member order to ensure correct initialization

### DIFF
--- a/test/TestUtils.cpp
+++ b/test/TestUtils.cpp
@@ -3,6 +3,9 @@
 
 #include "catch2/catch.hpp"
 #include "StringUtils.hpp"
+#include "DynamicFunction.hpp"
+
+#include <sysinfoapi.h>
 
 // Tests for StringUtils.hpp
 
@@ -58,4 +61,25 @@ TEST_CASE("ListEnumToHexString format correctly", "[stringUtils]")
 
     CHECK(ListEnumToHexString(gsl::span{std::vector{Pizza::Cheese}}, L"-", 4) == std::wstring(L"0000"));
     CHECK(ListEnumToHexString(gsl::span{std::vector{Pizza::Peperoni, Pizza::Cheese}}, L"-", 4) == std::wstring(L"0001-0000"));
+}
+
+TEST_CASE("Dynamic function basic behavior works", "[dynamicFunction]")
+{
+    SECTION("Loading an valid function from a valid module works")
+    {
+        CHECK_NOTHROW([]() {
+            DynamicFunction<decltype(::GetTickCount)> dynFun{L"kernel32.dll", "GetTickCount"};
+            dynFun();
+        }());
+    }
+
+    SECTION("Loading from a non-existing module throws")
+    {
+        CHECK_THROWS([]() { DynamicFunction<decltype(::GetTickCount)> dynFun{L"dummy.dll", "GetNativeSystemInfo"}; }());
+    }
+
+    SECTION("Loading a non-existing function throws")
+    {
+        CHECK_THROWS([]() { DynamicFunction<decltype(::GetTickCount)> dynFun{L"kernel32.dll", "dummy"}; }());
+    }
 }

--- a/util/DynamicFunction.hpp
+++ b/util/DynamicFunction.hpp
@@ -40,6 +40,6 @@ private:
     }
 
 private:
-    std::function<R(Args...)> m_function;
     wil::unique_hmodule m_module;
+    std::function<R(Args...)> m_function;
 };


### PR DESCRIPTION
### Goals

Fix the `DynamicFunction` class failing to load functions properly.

### Technical Details

The member of `DynamicFunction` were declared in the wrong order, causing the function to be initialized before the module was loaded.

This is already fixed in #14 but creating this PR to fast-track the fix.

### Testing

Added unit tests checking functions are loaded properly.

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formated with clang-format
- [x] Newly added code include doxygen-style comments
- [x] Unit tests are succeeding
