### PR TITLE
Improvements to the Workqueue

### DIFF
--- a/test/TestUtils.cpp
+++ b/test/TestUtils.cpp
@@ -4,8 +4,12 @@
 #include "catch2/catch.hpp"
 #include "StringUtils.hpp"
 #include "DynamicFunction.hpp"
+#include "WorkQueue.hpp"
 
 #include <sysinfoapi.h>
+
+#include <chrono>
+using namespace std::chrono_literals;
 
 // Tests for StringUtils.hpp
 
@@ -81,5 +85,187 @@ TEST_CASE("Dynamic function basic behavior works", "[dynamicFunction]")
     SECTION("Loading a non-existing function throws")
     {
         CHECK_THROWS([]() { DynamicFunction<decltype(::GetTickCount)> dynFun{L"kernel32.dll", "dummy"}; }());
+    }
+}
+
+TEST_CASE("Work queues execute work items", "[workQueue]")
+{
+
+    SECTION("A work item is exectuted")
+    {
+        SerializedWorkQueue<std::function<void(void)>> wq;
+        wil::slim_event event;
+        wq.Submit([&] { event.SetEvent(); });
+
+        CHECK(event.wait(50 /* ms */));
+    }
+
+    SECTION("Any callable type is supported and return value are ignored")
+    {
+        struct Work {
+            int operator()()
+            {
+                event.SetEvent();
+                return 42;
+            }
+            wil::slim_event& event;
+        };
+
+        SerializedWorkQueue<Work> wq;
+        wil::slim_event event;
+        wq.Submit(Work{event});
+        CHECK(event.wait(50 /* ms */));
+    }
+
+    SECTION("Work items are executed asychronously in a different thread")
+    {
+        SerializedWorkQueue<std::function<void(void)>> wq;
+        wil::slim_event event;
+        wil::slim_event event2;
+        wq.Submit([&] {
+            event2.wait();
+            event.SetEvent();
+        });
+
+        event2.SetEvent();
+        CHECK(event.wait(50 /* ms */));
+    }
+}
+
+TEST_CASE("Work item cancellation works", "[workQueue]")
+{
+    // Check that Cancel wait for currently running work items completion and cancel any pending one
+    const int workScheduled = 10;
+    std::atomic_int workStarted{0};
+    std::atomic_int workCompleted{0};
+    auto f = [&] {
+        ++workStarted;
+        std::this_thread::sleep_for(10ms);
+        ++workCompleted;
+    };
+
+    WorkQueue<std::function<void()>, 2, 2> wq;
+    for (auto i = 0; i < workScheduled; ++i)
+    {
+        wq.Submit(f);
+    }
+    wq.Cancel();
+
+    CHECK(workStarted == workCompleted);
+    CHECK(workStarted <= workScheduled);
+}
+
+TEST_CASE("Work item are serialized in a serialized queue", "[workQueue]")
+{
+    // Work items are serialized in a serialized queue
+    SerializedWorkQueue<std::function<void(void)>> wq;
+    wil::slim_event event;
+    std::atomic_bool firstWorkComplete;
+    bool testPassed = false;
+
+    wq.Submit([&] {
+        std::this_thread::sleep_for(10ms);
+        firstWorkComplete = true;
+    });
+    wq.Submit([&] {
+        testPassed = firstWorkComplete;
+        event.SetEvent();
+    });
+
+    CHECK(event.wait(50 /* ms */));
+    CHECK(testPassed);
+}
+
+TEST_CASE("Light stress", "[workQueue]")
+{
+    SECTION("All work item run in light stress situation")
+    {
+        WorkQueue<std::function<void(void)>, 5, 5> wq;
+        wil::slim_event event;
+        std::atomic<int> count;
+        constexpr auto numTasks = 1000;
+
+        for (auto i = 0; i < numTasks; ++i)
+        {
+            wq.Submit([&] {
+                auto v = ++count;
+                if (v == numTasks)
+                {
+                    event.SetEvent();
+                }
+            });
+        }
+
+        CHECK(event.wait(500 /* ms */));
+    }
+
+    SECTION("All work item are serialized in light stress situation")
+    {
+        SerializedWorkQueue<std::function<void(void)>> wq;
+        wil::slim_event event;
+        auto count = 0;
+        constexpr auto numTasks = 1000;
+        bool testPassed = true;
+
+        for (auto i = 0; i < numTasks; ++i)
+        {
+            wq.Submit([&, id = i] {
+                if (id != count++)
+                {
+                    testPassed = false;
+                }
+                if (count == numTasks)
+                {
+                    event.SetEvent();
+                }
+            });
+        }
+
+        CHECK(event.wait(500 /* ms */));
+        CHECK(testPassed);
+    }
+}
+
+TEST_CASE("Work runner basic tests", "[workQueue]")
+{
+    SECTION("Work items are executed")
+    {
+        SerializedWorkRunner wq;
+        wil::slim_event event;
+        wil::slim_event event2;
+        wq.Run([&] {
+            event2.wait();
+            event.SetEvent();
+        });
+
+        event2.SetEvent();
+        CHECK(event.wait(50 /* ms */));
+    }
+
+    SECTION("Return values are ignored if not waited for")
+    {
+        SerializedWorkRunner wq;
+        // The task can return a value, which is ignored
+        wil::slim_event event;
+        wq.Run([&] {
+            event.SetEvent();
+            return "pizza";
+        });
+        CHECK(event.wait(50 /* ms */));
+    }
+
+    SECTION("One can wait for the return value")
+    {
+        SerializedWorkRunner wq;
+        const auto r = wq.RunAndWait([&] { return 42; });
+        CHECK(r == 42);
+    }
+
+    SECTION("One can wait without a return value")
+    {
+        SerializedWorkRunner wq;
+        int a = 0;
+        wq.RunAndWait([&] { a = 42; });
+        CHECK(a == 42);
     }
 }

--- a/util/WorkQueue.hpp
+++ b/util/WorkQueue.hpp
@@ -77,6 +77,16 @@ private:
             ::SetThreadpoolCallbackPool(&m_threadpoolEnv, m_threadPool.get());
         }
 
+        ~ThreadPool()
+        {
+            Reset();
+        }
+
+        ThreadPool(const ThreadPool&) = delete;
+        ThreadPool(ThreadPool&&) = delete;
+        ThreadPool& operator=(const ThreadPool&) = delete;
+        ThreadPool& operator=(ThreadPool&&) = delete;
+
         wil::unique_threadpool_work CreateWork(PTP_WORK_CALLBACK callback, void* context)
         {
             wil::unique_threadpool_work work(::CreateThreadpoolWork(callback, context, &m_threadpoolEnv));
@@ -84,9 +94,10 @@ private:
             return work;
         }
 
-        void Cancel() noexcept
+        void Reset() noexcept
         {
             m_threadPool.reset();
+            ::DestroyThreadpoolEnvironment(&m_threadpoolEnv);
         }
     };
 

--- a/util/WorkQueue.hpp
+++ b/util/WorkQueue.hpp
@@ -83,6 +83,11 @@ private:
             THROW_LAST_ERROR_IF_NULL(work.get());
             return work;
         }
+
+        void Cancel() noexcept
+        {
+            m_threadPool.reset();
+        }
     };
 
     static void CALLBACK WorkCallback(_Inout_ PTP_CALLBACK_INSTANCE, _In_ void* context, _Inout_ PTP_WORK) noexcept
@@ -97,7 +102,7 @@ private:
                 return;
             }
 
-            workItem = std::move(pThis->m_workQueue.front());
+            workItem.emplace(std::move(pThis->m_workQueue.front()));
             pThis->m_workQueue.pop_front();
         }
 
@@ -134,7 +139,6 @@ public:
         }};
         m_workQueue.Submit(std::move(t));
     }
-
 
     /// @brief Helper to execute a task in the workqueue and wait its completion
     template<class F, std::enable_if_t<std::is_invocable_v<F>, int> = 1>


### PR DESCRIPTION
### Goals

- Use `std::packaged_task` instead of a manual re-implementation
- Fix a potential cleanup issue (not affecting this codebase, but see on other pieces of code)
- Add unit tests

### Technical Details

- Use std::package_task
- Add a `Reset` call to the `Threadpool` struct to allow closing the threadpool.

### Testing

Unit tests are working

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formated with clang-format
- [x] Newly added code include doxygen-style comments
- [x] Unit tests are succeeding
