### PR TITLE
Add a timeout to socket send and receive operations

### DIFF
--- a/lib/Connection.cpp
+++ b/lib/Connection.cpp
@@ -24,7 +24,7 @@ void Connection::Run()
     }
     catch (...)
     {
-        LOG_WIN32_MSG(ERROR_INVALID_MESSAGE, "Failed to received a message");
+        LOG_WIN32_MSG(ERROR_INVALID_DATA, "Failed to received a message");
         return;
     }
 
@@ -83,7 +83,7 @@ void Connection::Run()
             break;
         }
         default:
-            THROW_WIN32_MSG(ERROR_INVALID_MESSAGE, "Ignoring unknown command ID: %d", request->hdr.operation);
+            THROW_WIN32_MSG(ERROR_INVALID_DATA, "Ignoring unknown command ID: %d", request->hdr.operation);
         }
 
         Log::Trace(

--- a/lib/SocketHelpers.cpp
+++ b/lib/SocketHelpers.cpp
@@ -103,7 +103,7 @@ static bool ReceiveBytes(const wil::unique_socket& socket, gsl::span<uint8_t> bu
     while (buffer.size_bytes() > 0)
     {
         // Wait until there is something to read (or fail after a timeout)
-        const timeval timeout{0, 500000}; // 0.5 sec timeout
+        constexpr timeval timeout{.tv_sec{0}, .tv_usec{500000}}; // 0.5 sec timeout
         fd_set read_set{};
         FD_SET(socket.get(), &read_set);
         const auto socket_ready = select(0, &read_set, nullptr, nullptr, &timeout);
@@ -165,7 +165,7 @@ static void SendBytes(wil::unique_socket& socket, gsl::span<const uint8_t> dataT
     while (dataToSend.size_bytes() > 0)
     {
         // Wait until the destination is ready to receive
-        const timeval timeout{0, 500000}; // 0.5 sec timeout
+        constexpr timeval timeout{.tv_sec{0}, .tv_usec{500000}}; // 0.5 sec timeout
         fd_set write_set{};
         FD_SET(socket.get(), &write_set);
         const auto socket_ready = select(0, nullptr, &write_set, nullptr, &timeout);

--- a/lib/SocketHelpers.cpp
+++ b/lib/SocketHelpers.cpp
@@ -102,6 +102,21 @@ static bool ReceiveBytes(const wil::unique_socket& socket, gsl::span<uint8_t> bu
 {
     while (buffer.size_bytes() > 0)
     {
+        // Wait until there is something to read (or fail after a timeout)
+        const timeval timeout{0, 500000}; // 0.5 sec timeout
+        fd_set read_set{};
+        FD_SET(socket.get(), &read_set);
+        const auto socket_ready = select(0, &read_set, nullptr, nullptr, &timeout);
+        if (socket_ready == SOCKET_ERROR)
+        {
+            THROW_LAST_ERROR_MSG("Error while waiting for a message");
+        }
+        else if (socket_ready == 0)
+        {
+            THROW_WIN32_MSG(ERROR_TIMEOUT, "Timeout while waiting for a message");
+        }
+
+        // Read as many bytes as possible up to the buffer size
         const auto transfer_size = recv(socket.get(), reinterpret_cast<char*>(buffer.data()), static_cast<int>(buffer.size_bytes()), 0);
         if (transfer_size < 0)
         {
@@ -147,9 +162,23 @@ std::optional<Message> ReceiveProxyWifiMessage(const wil::unique_socket& socket)
 
 static void SendBytes(wil::unique_socket& socket, gsl::span<const uint8_t> dataToSend)
 {
-    // TODO: Is it needed to loop on a send?
     while (dataToSend.size_bytes() > 0)
     {
+        // Wait until the destination is ready to receive
+        const timeval timeout{0, 500000}; // 0.5 sec timeout
+        fd_set write_set{};
+        FD_SET(socket.get(), &write_set);
+        const auto socket_ready = select(0, nullptr, &write_set, nullptr, &timeout);
+        if (socket_ready == SOCKET_ERROR)
+        {
+            THROW_LAST_ERROR_MSG("Error while waiting to send a message");
+        }
+        else if (socket_ready == 0)
+        {
+            THROW_WIN32_MSG(ERROR_TIMEOUT, "Timeout while waiting to send a message");
+        }
+
+        // Send the message
         const auto transfer_size =
             send(socket.get(), reinterpret_cast<const char*>(dataToSend.data()), wil::safe_cast<int>(dataToSend.size_bytes()), 0);
         if (transfer_size <= 0)


### PR DESCRIPTION
### Goals

After the system goes to S3 sleep, hv_socket would sometime lose a message payload: the guest proxy_wifi driver could connect to the host and the connection would be accepted, but no data would ever be received by the host.
It results in a deadlock, both the host and the guest waiting to receive a message (request for the host, answer for the guest), none of them closing the socket.

This PR solves this by adding timeout to receive and send operations: if data is not received on the socket fast enough, it will be closed, unblocking both parties.

### Technical Details

Use `select` to wait until the socket is ready to send data / until there is data to read, or timeout after 0.5 second.

### Testing

- Unit tests are passing
- Manual testing: triggered the error scenario by preventing the guest from sending the message, validated that the host timeout as expected

### Reviewer Focus

Does the timeout value seem appropriate? I don't want it too aggressive since its mostly to mitigate a very specific issue.

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formated with clang-format
- [x] Newly added code includes doxygen-style comments
- [x] Unit tests are succeeding
