### PR TITLE
Allow the client to approve or deny connection requests from the guest

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can additionnaly setup a logger to chose where logs will be output.
 
     class MyObserver: public ProxyWifiObserver
     {
-        void Authorization::GuestRequestingToConnect(OperationType type, const ConnectRequestArgs& connectionInfo) noexcept override
+        Authorization AuthorizeGuestConnectionRequest(OperationType type, const ConnectRequestArgs& connectionInfo) noexcept override
         {
             std::cout << "The guest requested a connection" << std::endl;
             return Authorization::Approve;

--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ You can additionnaly setup a logger to chose where logs will be output.
 
     class MyObserver: public ProxyWifiObserver
     {
-        void OnGuestConnectionRequest(OperationType type, const DOT11_SSID& ssid) noexcept override
+        void Authorization::GuestRequestingToConnect(OperationType type, const ConnectRequestArgs& connectionInfo) noexcept override
         {
             std::cout << "The guest requested a connection" << std::endl;
+            return Authorization::Approve;
         }
     };
 

--- a/include/ProxyWifi/ProxyWifiService.hpp
+++ b/include/ProxyWifi/ProxyWifiService.hpp
@@ -52,8 +52,9 @@ public:
 /// @brief Indicate the status of a guest initiated operation
 enum class OperationStatus
 {
-    Succeeded,
-    Failed
+    Succeeded, ///< The operation was completed successfully and success will be indicated to the guest
+    Failed,    ///< The operation failed and failure will be indicated to the guest
+    Denied     ///< The operation was denied by the client and failure will be indicated to the guest
 };
 
 /// @brief List basic information about a Wi-Fi network
@@ -64,26 +65,6 @@ struct WifiNetworkInfo
 
     DOT11_SSID ssid = {};
     DOT11_MAC_ADDRESS bssid = {};
-};
-
-/// @brief Package the argugments for the `OnConnection` callback
-struct OnConnectionArgs {
-    /// The host interface that connected
-    GUID interfaceGuid{};
-    /// The ssid of the connected network
-    DOT11_SSID connectedNetwork{};
-    /// The authentication algorithm of the connected network, for host connections
-    /// Remarks: This is the auth algo that is reported to the guest in scan results,
-    /// it might differ from the actual auth algo used by the host
-    DOT11_AUTH_ALGORITHM authAlgo{DOT11_AUTH_ALGO_80211_OPEN};
-};
-
-/// @brief Package the argugments for the `OnDisconnection` callback
-struct OnDisconnectionArgs {
-    /// The host interface that disconnected
-    GUID interfaceGuid{};
-    /// The ssid of the disconnected network
-    DOT11_SSID disconnectedNetwork{};
 };
 
 /// @brief Indicate the impact a guest requested operation will have on the host
@@ -100,26 +81,31 @@ class ProxyWifiObserver
 public:
     virtual ~ProxyWifiObserver() = default;
 
-    struct ConnectRequestArgs {
+    struct ConnectRequestArgs
+    {
         DOT11_SSID ssid;
     };
 
-    struct ConnectCompleteArgs {
+    struct ConnectCompleteArgs
+    {
         GUID interfaceGuid;
         DOT11_SSID ssid;
         DOT11_AUTH_ALGORITHM authAlgo;
     };
 
-    struct DisconnectRequestArgs {
+    struct DisconnectRequestArgs
+    {
         DOT11_SSID ssid;
     };
 
-    struct DisconnectCompleteArgs {
+    struct DisconnectCompleteArgs
+    {
         GUID interfaceGuid;
         DOT11_SSID ssid;
     };
 
-    enum Authorization
+    /// @brief Indicate whether proxy_wifi should proceed with a guest request or answer immediately with a failure
+    enum class Authorization
     {
         Approve,
         Deny
@@ -136,32 +122,31 @@ public:
     }
 
     /// @brief The guest requested a connection to a network
-    /// @return Return `Authorization::Approve` to let the connection proceed, return `Authorization::Deny` to answer to the guest with a failure
-    /// If `type == OperationType::HostMirroring`, an host inteface is already connected to the network, otherwise, one will be
-    /// connected. The connection won't proceed until the callback returns
+    /// @return Return `Authorization::Approve` to let the connection proceed, return `Authorization::Deny` to answer to the guest
+    /// with a failure If `type == OperationType::HostMirroring`, an host inteface is already connected to the network, otherwise,
+    /// one will be connected. The connection won't proceed until the callback returns
     virtual Authorization AuthorizeGuestConnectionRequest(OperationType /* type */, const ConnectRequestArgs& /* connectionInfo */) noexcept
     {
         return Authorization::Approve;
     }
 
     /// @brief A guest connection request was processed
-    /// If `type == OperationType::HostMirroring`, an host inteface was already connected to the network, otherwise, one has been be connected
-    /// The response won't be sent to the guest until this callback returns
-    virtual void OnGuestConnectionCompletion(
-        OperationType /* type */, OperationStatus /* status */, const ConnectCompleteArgs& /* connectionInfo */) noexcept
+    /// If `type == OperationType::HostMirroring`, an host inteface was already connected to the network, otherwise, one has been
+    /// be connected The response won't be sent to the guest until this callback returns
+    virtual void OnGuestConnectionCompletion(OperationType /* type */, OperationStatus /* status */, const ConnectCompleteArgs& /* connectionInfo */) noexcept
     {
     }
 
     /// @brief The guest requested a disconnection from the connected network
-    /// If `type == OperationType::HostMirroring`, the host won't be impacted, otherwise, a matching host interface will be disconnected
-    /// The disconnection won't proceed until the callback returns
+    /// If `type == OperationType::HostMirroring`, the host won't be impacted, otherwise, a matching host interface will be
+    /// disconnected The disconnection won't proceed until the callback returns
     virtual void OnGuestDisconnectionRequest(OperationType /* type */, const DisconnectRequestArgs& /* connectionInfo */) noexcept
     {
     }
 
     /// @brief A guest disconnection request was processed
-    /// If `type == OperationType::HostMirroring`, this was a no-op for the host, otherwise, a matching host interface has been disconnected
-    /// The response won't be sent to the guest until this callback returns
+    /// If `type == OperationType::HostMirroring`, this was a no-op for the host, otherwise, a matching host interface has been
+    /// disconnected The response won't be sent to the guest until this callback returns
     virtual void OnGuestDisconnectionCompletion(OperationType /* type */, OperationStatus /* status */, const DisconnectCompleteArgs& /* disconnectionInfo */) noexcept
     {
     }

--- a/include/ProxyWifi/ProxyWifiService.hpp
+++ b/include/ProxyWifi/ProxyWifiService.hpp
@@ -119,6 +119,12 @@ public:
         DOT11_SSID ssid;
     };
 
+    enum Authorization
+    {
+        Approve,
+        Deny
+    };
+
     /// @brief An host WiFi interface connected to a network
     virtual void OnHostConnection(const ConnectCompleteArgs& /* connectionInfo */) noexcept
     {
@@ -130,10 +136,12 @@ public:
     }
 
     /// @brief The guest requested a connection to a network
+    /// @return Return `Authorization::Approve` to let the connection proceed, return `Authorization::Deny` to answer to the guest with a failure
     /// If `type == OperationType::HostMirroring`, an host inteface is already connected to the network, otherwise, one will be
-    /// connected The connection won't proceed until the callback returns
-    virtual void OnGuestConnectionRequest(OperationType /* type */, const ConnectRequestArgs& /* connectionInfo */) noexcept
+    /// connected. The connection won't proceed until the callback returns
+    virtual Authorization AuthorizeGuestConnectionRequest(OperationType /* type */, const ConnectRequestArgs& /* connectionInfo */) noexcept
     {
+        return Authorization::Approve;
     }
 
     /// @brief A guest connection request was processed

--- a/lib/OperationHandler.cpp
+++ b/lib/OperationHandler.cpp
@@ -253,7 +253,7 @@ ConnectResponse OperationHandler::HandleConnectRequestSerialized(const ConnectRe
     {
         // No interface to connect with: fails directly
         Log::Trace(L"No interfaces are present");
-        return ConnectResponse{WlanStatus::UnspecifiedFailure, connectRequest->bssid, m_sessionId};
+        return ConnectResponse{WlanStatus::UnspecifiedFailure, connectRequest->bssid, ++m_sessionId};
     }
 
     for (const auto& wlanIntf : m_wlanInterfaces)

--- a/lib/OperationHandler.cpp
+++ b/lib/OperationHandler.cpp
@@ -62,9 +62,9 @@ void OperationHandler::SendGuestNotification(std::variant<DisconnectNotif, Signa
     }
 }
 
-void OperationHandler::OnGuestConnectionRequest(OperationType type, const Ssid& ssid) noexcept
+ProxyWifiObserver::Authorization OperationHandler::AuthorizeGuestConnectionRequest(OperationType type, const Ssid& ssid) noexcept
 {
-    m_clientNotificationQueue.RunAndWait([&] {
+    return m_clientNotificationQueue.RunAndWait([&] {
         Log::Info(
             L"Notifying the client of a guest connection request. Type: %ws, Ssid: %ws",
             ToString(type),
@@ -72,16 +72,20 @@ void OperationHandler::OnGuestConnectionRequest(OperationType type, const Ssid& 
 
         if (m_pClientObserver)
         {
-            m_pClientObserver->OnGuestConnectionRequest(type, {ssid});
+            return m_pClientObserver->AuthorizeGuestConnectionRequest(type, {ssid});
         }
+
+        return ProxyWifiObserver::Authorization::Approve;
     });
 }
 
-void OperationHandler::OnGuestConnectionCompletion(OperationType type, OperationStatus status, const GUID& interfaceGuid, const Ssid& ssid, DOT11_AUTH_ALGORITHM authAlgo) noexcept
+void OperationHandler::OnGuestConnectionCompletion(
+    OperationType type, OperationStatus status, const GUID& interfaceGuid, const Ssid& ssid, DOT11_AUTH_ALGORITHM authAlgo) noexcept
 {
     m_clientNotificationQueue.RunAndWait([&] {
         Log::Info(
-            L"Notifying the client of a guest connection completion. Type: %ws, Status: %ws, Interface: %ws, Ssid: %ws, AuthAlgo: %ws",
+            L"Notifying the client of a guest connection completion. Type: %ws, Status: %ws, Interface: %ws, Ssid: %ws, "
+            L"AuthAlgo: %ws",
             ToString(type),
             ToString(status),
             GuidToString(interfaceGuid).c_str(),
@@ -262,16 +266,31 @@ ConnectResponse OperationHandler::HandleConnectRequestSerialized(const ConnectRe
             const auto connectedIntfGuid = wlanIntf->GetGuid();
             m_guestConnection = {ConnectionType::Mirrored, connectedIntfGuid, ssid};
 
-            Log::Info(L"Successfully mirrored the connection on interface %ws. Notifying clients.", GuidToString(connectedIntfGuid).c_str());
-            OnGuestConnectionRequest(OperationType::HostMirroring, ssid);
-            OnGuestConnectionCompletion(OperationType::HostMirroring, OperationStatus::Succeeded, connectedIntfGuid, ssid, networkInfo->auth);
+            Log::Info(
+                L"Successfully mirrored the connection on interface %ws. Notifying clients.", GuidToString(connectedIntfGuid).c_str());
 
-            return ConnectResponse{WlanStatus::Success, networkInfo->bssid, ++m_sessionId};
+            auto connectionStatus = WlanStatus::Success;
+            auto operationStatus = OperationStatus::Succeeded;
+
+            // Notify the client of the connection request and ask for permission, fail the request if they deny it
+            if (AuthorizeGuestConnectionRequest(OperationType::HostMirroring, ssid) == ProxyWifiObserver::Authorization::Deny)
+            {
+                connectionStatus = WlanStatus::UnspecifiedFailure;
+                operationStatus = OperationStatus::Failed;
+            }
+
+            OnGuestConnectionCompletion(OperationType::HostMirroring, operationStatus, connectedIntfGuid, ssid, networkInfo->auth);
+            return ConnectResponse{connectionStatus, networkInfo->bssid, ++m_sessionId};
         }
     }
 
-    // At this point, an host interface will be connected. Notify the client of a guest direct connection
-    OnGuestConnectionRequest(OperationType::GuestDirected, ssid);
+    // No host interface is connected to the request network: if the request go through, we will connect one on the host
+    // Notify the client of the connection request and ask for permission, fail the request if they deny it
+    if (AuthorizeGuestConnectionRequest(OperationType::GuestDirected, ssid) == ProxyWifiObserver::Authorization::Deny)
+    {
+        OnGuestConnectionCompletion(OperationType::HostMirroring, OperationStatus::Failed, {}, ssid, {});
+        return ConnectResponse{WlanStatus::UnspecifiedFailure, Bssid{}, ++m_sessionId};
+    }
 
     try
     {
@@ -326,7 +345,8 @@ ConnectResponse OperationHandler::HandleConnectRequestSerialized(const ConnectRe
                 m_guestConnection = {ConnectionType::GuestDirected, connectedIntfGuid, ssid};
 
                 Log::Info(L"Successfully connected on interface %ws. Notifying clients.", GuidToString(connectedIntfGuid).c_str());
-                OnGuestConnectionCompletion(OperationType::GuestDirected, OperationStatus::Succeeded, connectedIntfGuid, ssid, networkInfo.auth);
+                OnGuestConnectionCompletion(
+                    OperationType::GuestDirected, OperationStatus::Succeeded, connectedIntfGuid, ssid, networkInfo.auth);
 
                 return ConnectResponse{connectionResult, networkInfo.bssid, ++m_sessionId};
             }
@@ -375,10 +395,10 @@ DisconnectResponse OperationHandler::HandleDisconnectRequestSerialized(const Dis
         const auto guestConnectInfo = m_guestConnection;
         m_guestConnection.reset();
 
-        OnGuestDisconnectionCompletion(OperationType::HostMirroring, OperationStatus::Succeeded, guestConnectInfo->interfaceGuid, guestConnectInfo->ssid);
+        OnGuestDisconnectionCompletion(
+            OperationType::HostMirroring, OperationStatus::Succeeded, guestConnectInfo->interfaceGuid, guestConnectInfo->ssid);
         return DisconnectResponse{};
     }
-
 
     // At this point, an host interface will be disconnected. Notify the client (make sure it is notified of the completion on each path)
     OnGuestDisconnectionRequest(OperationType::GuestDirected, m_guestConnection->ssid);
@@ -387,7 +407,8 @@ DisconnectResponse OperationHandler::HandleDisconnectRequestSerialized(const Dis
         const auto guestConnectInfo = m_guestConnection;
         m_guestConnection.reset();
 
-        OnGuestDisconnectionCompletion(OperationType::GuestDirected, OperationStatus::Succeeded, guestConnectInfo->interfaceGuid, guestConnectInfo->ssid);
+        OnGuestDisconnectionCompletion(
+            OperationType::GuestDirected, OperationStatus::Succeeded, guestConnectInfo->interfaceGuid, guestConnectInfo->ssid);
         return DisconnectResponse{};
     };
 

--- a/lib/OperationHandler.cpp
+++ b/lib/OperationHandler.cpp
@@ -276,7 +276,7 @@ ConnectResponse OperationHandler::HandleConnectRequestSerialized(const ConnectRe
             if (AuthorizeGuestConnectionRequest(OperationType::HostMirroring, ssid) == ProxyWifiObserver::Authorization::Deny)
             {
                 connectionStatus = WlanStatus::UnspecifiedFailure;
-                operationStatus = OperationStatus::Failed;
+                operationStatus = OperationStatus::Denied;
             }
 
             OnGuestConnectionCompletion(OperationType::HostMirroring, operationStatus, connectedIntfGuid, ssid, networkInfo->auth);
@@ -288,7 +288,7 @@ ConnectResponse OperationHandler::HandleConnectRequestSerialized(const ConnectRe
     // Notify the client of the connection request and ask for permission, fail the request if they deny it
     if (AuthorizeGuestConnectionRequest(OperationType::GuestDirected, ssid) == ProxyWifiObserver::Authorization::Deny)
     {
-        OnGuestConnectionCompletion(OperationType::HostMirroring, OperationStatus::Failed, {}, ssid, {});
+        OnGuestConnectionCompletion(OperationType::HostMirroring, OperationStatus::Denied, {}, ssid, {});
         return ConnectResponse{WlanStatus::UnspecifiedFailure, Bssid{}, ++m_sessionId};
     }
 

--- a/lib/OperationHandler.hpp
+++ b/lib/OperationHandler.hpp
@@ -81,7 +81,7 @@ private:
     void SendGuestNotification(std::variant<DisconnectNotif, SignalQualityNotif> notif);
 
     /// @brief Notify the guest of guest operation request and completion
-    void OnGuestConnectionRequest(OperationType type, const Ssid& ssid) noexcept;
+    ProxyWifiObserver::Authorization AuthorizeGuestConnectionRequest(OperationType type, const Ssid& ssid) noexcept;
     void OnGuestConnectionCompletion(OperationType type, OperationStatus status, const GUID& interfaceGuid, const Ssid& ssid, DOT11_AUTH_ALGORITHM authAlgo) noexcept;
     void OnGuestDisconnectionRequest(OperationType type, const Ssid& ssid) noexcept;
     void OnGuestDisconnectionCompletion(OperationType type, OperationStatus status, const GUID& interfaceGuid, const Ssid& ssid) noexcept;

--- a/test/TestOpHandler.cpp
+++ b/test/TestOpHandler.cpp
@@ -570,7 +570,6 @@ TEST_CASE("The client can approve or deny guest connection requests", "[wlansvcO
         auto connectResponse = opHandler->HandleConnectRequest(connectRequest);
         opHandler->DrainClientNotifications();
         CHECK(connectResponse->result_code == WI_EnumValue(WlanStatus::UnspecifiedFailure));
-
     }
 
     SECTION("The client can approve a host mirroring connection request")


### PR DESCRIPTION
### Goals

In some situations, the client might want to prevent the guest from completing a connection request.
This can be the case, for instance, if the client wanted the guest to mirror a host connection, but by the time the connection request reaches the driver, the host already disconnected.

### Technical Details

The `OnGuestConnectionRequest` callback is replaced by a `AuthorizeGuestConnectionRequest` callback.
`Authorization::Approve` or `Authorization::Deny` can be returned from this callback by the client. If `Deny` is returned, proxy_wifi won't try to connect the host and will answer with a failure to the guest.

### Testing

- Unit tests
- Manual testing with a VM

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formated with clang-format
- [x] Newly added code include doxygen-style comments
- [x] Unit tests are succeeding
