### PR TITLE
Use 5GHz for client simulated network

### DIFF
--- a/lib/Networks.hpp
+++ b/lib/Networks.hpp
@@ -16,7 +16,7 @@ struct FakeBss
 {
     BssCapability capabilities = BssCapability::Ess;
     int32_t rssi = -50;
-    uint32_t channelCenterFreq = 2432000; // 2.4GHz by default
+    uint32_t channelCenterFreq = 5240000; // 5GHz by default
     uint16_t beaconInterval = 0;
     Bssid bssid{};
     Ssid ssid;
@@ -43,7 +43,7 @@ struct ScannedBss
     Ssid ssid;
     uint16_t capabilities = 0;
     int32_t rssi = -50;
-    uint32_t channelCenterFreq = 2432000; // 2.4GHz by default
+    uint32_t channelCenterFreq = 5240000; // 5GHz by default
     uint16_t beaconInterval = 0;
     std::vector<uint8_t> ies;
 };

--- a/test/TestOpHandler.cpp
+++ b/test/TestOpHandler.cpp
@@ -150,6 +150,8 @@ TEST_CASE("Process a scan requests", "[wlansvcOpHandler]")
             reinterpret_cast<uint8_t*>(&scanResponse->bss[0]) + scanResponse->bss[0].ie_offset, scanResponse->bss[0].ie_size};
         CHECK(std::search(ie.begin(), ie.end(), ssid.value().begin(), ssid.value().end()) != ie.end());
         CHECK(std::search(ie.begin(), ie.end(), Mock::c_wpa2pskRsnIe.begin(), Mock::c_wpa2pskRsnIe.end()) != ie.end());
+        // Client networks are simulated using 5GHz
+        CHECK(scanResponse->bss[0].channel_center_freq == 5240000);
     }
 }
 


### PR DESCRIPTION
### Goals

Simulate client networks as 5GHz networks instead of 2.4GHz networks

### Technical Details

Use a 5GHz frequency as the default for fake networks results.

### Testing

Unit tests have been updated and are passing

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formatted with clang-format
- [x] Newly added code include doxygen-style comments
- [x] Unit tests are succeeding
