### PR TITLE
Upgrade to SDK 22621

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   build_analyze:
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: False
       matrix:
@@ -22,7 +22,6 @@ jobs:
         include:
           - arch: x64
             build_type: Debug
-            test: True
             codeql: True
 
     name: build_${{matrix.arch}}_${{matrix.build_type}}
@@ -40,12 +39,12 @@ jobs:
     - name: Install Windows SDK
       uses: GuillaumeFalourd/setup-windows10-sdk-action@v1
       with:
-        sdk-version: 19041
+        sdk-version: 22621
 
     - name: Build
       run: |
         mkdir build && pushd build
-        cmake -A ${{ matrix.arch }} -DCMAKE_SYSTEM_VERSION=10.0.19041.0 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+        cmake -A ${{ matrix.arch }} -DCMAKE_SYSTEM_VERSION=10.0.22621.0 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
         cmake --build . --parallel --config ${{ matrix.build_type }}
         popd
 
@@ -61,7 +60,7 @@ jobs:
 
   run_unit_tests:
     needs: build_analyze
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - name: Download test artifact
       id: download

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             codeql: True
             sdk_version: 19041
 
-    name: build_${{matrix.arch}}_${{matrix.build_type}}
+    name: build_${{matrix.arch}}_${{matrix.build_type}}_${{matrix.sdk_version}}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,13 @@ jobs:
       matrix:
         arch: [x64, arm64]
         build_type: [Debug, Release]
+        sdk_version: [19041, 22621]
       # Run unit tests and CodeQL analysis on x64Debug only
         include:
           - arch: x64
             build_type: Debug
             codeql: True
+            sdk_version: 19041
 
     name: build_${{matrix.arch}}_${{matrix.build_type}}
 
@@ -39,12 +41,12 @@ jobs:
     - name: Install Windows SDK
       uses: GuillaumeFalourd/setup-windows10-sdk-action@v1
       with:
-        sdk-version: 22621
+        sdk-version: ${{ matrix.sdk_version }}
 
     - name: Build
       run: |
         mkdir build && pushd build
-        cmake -A ${{ matrix.arch }} -DCMAKE_SYSTEM_VERSION=10.0.22621.0 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+        cmake -A ${{ matrix.arch }} -DCMAKE_SYSTEM_VERSION=10.0.${{ matrix.sdk_version }}.0 -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
         cmake --build . --parallel --config ${{ matrix.build_type }}
         popd
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,19 +10,6 @@ option(MICROSOFT_TELEMETRY "Enable Microsoft telemetry collection" OFF)
 
 include(FetchContent)
 
-# Configure GSL dependency
-FetchContent_Declare(GSL
-    GIT_REPOSITORY "https://github.com/microsoft/GSL"
-    GIT_TAG "v3.1.0"
-    GIT_SHALLOW ON
-)
-
-FetchContent_GetProperties(GSL)
-if(NOT gsl_POPULATED)
-    FetchContent_Populate(GSL)
-    add_subdirectory(${gsl_SOURCE_DIR} ${gsl_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
-
 # Configure WIL dependency
 set(WIL_BUILD_TESTS OFF CACHE INTERNAL "Turn off wil tests")
 set(WIL_BUILD_PACKAGING OFF CACHE INTERNAL "Turn off wil packaging")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ FetchContent_MakeAvailable(WIL)
 
 # Default to debug build if unspecified
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Debug")
+    set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
 # Rationalize TARGET_PLATFORM
@@ -52,18 +52,19 @@ add_compile_definitions(
     WIN32_LEAN_AND_MEAN
 )
 
-if (MICROSOFT_TELEMETRY)
+if(MICROSOFT_TELEMETRY)
     add_compile_definitions(MICROSOFT_TELEMETRY)
 endif()
 
 add_subdirectory(lib)
 add_subdirectory(util)
 
-if (PROJECT_IS_TOP_LEVEL)
-  add_subdirectory(cmdline)
+if(PROJECT_IS_TOP_LEVEL)
+    add_subdirectory(cmdline)
 
-  include(CTest)
-  if (BUILD_TESTING)
-      add_subdirectory(test)
-  endif()
+    include(CTest)
+
+    if(BUILD_TESTING)
+        add_subdirectory(test)
+    endif()
 endif()

--- a/include/ProxyWifi/ProxyWifiService.hpp
+++ b/include/ProxyWifi/ProxyWifiService.hpp
@@ -4,6 +4,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <Windows.h>

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -13,7 +13,6 @@ target_link_libraries(proxy-wifi
         Mswsock.lib
         Ws2_32.lib
     PRIVATE
-        GSL
         WIL
         proxy-wifi-util
 )

--- a/lib/ClientWlanInterface.cpp
+++ b/lib/ClientWlanInterface.cpp
@@ -101,8 +101,8 @@ std::future<IWlanInterface::ScanResult> ClientWlanInterface::Scan(std::optional<
             L"ChannelCenterFreq: %d",
             BssidToString(fakeBss.bssid).c_str(),
             SsidToLogString(fakeBss.ssid.value()).c_str(),
-            ListEnumToHexString(gsl::span{fakeBss.akmSuites}).c_str(),
-            ListEnumToHexString(gsl::span{fakeBss.cipherSuites}).c_str(),
+            ListEnumToHexString(std::span{fakeBss.akmSuites}).c_str(),
+            ListEnumToHexString(std::span{fakeBss.cipherSuites}).c_str(),
             fakeBss.groupCipher ? WI_EnumValue(*fakeBss.groupCipher) : 0,
             fakeBss.channelCenterFreq);
 

--- a/lib/Iee80211Utils.hpp
+++ b/lib/Iee80211Utils.hpp
@@ -5,8 +5,9 @@
 #include <Windows.h>
 #include <wlanapi.h>
 #include <wil/common.h>
-#include <gsl/span>
 
+#include <array>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -186,7 +187,7 @@ public:
     {
     }
 
-    Ssid(const gsl::span<const uint8_t> rhs) :
+    Ssid(const std::span<const uint8_t> rhs) :
         m_ssid{rhs.begin(), rhs.end()}
     {
         if (rhs.size() > c_wlan_max_ssid_len)

--- a/lib/Messages.hpp
+++ b/lib/Messages.hpp
@@ -8,12 +8,12 @@
 #include <array>
 #include <algorithm>
 #include <cstdint>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <sstream>
 #include <vector>
 
-#include <gsl/span>
 #include <wil/safecast.h>
 
 #include "Iee80211Utils.hpp"
@@ -150,9 +150,9 @@ public:
         return get();
     }
 
-    gsl::span<uint8_t> AsBytes()
+    std::span<uint8_t> AsBytes()
     {
-        return gsl::span{m_buffer};
+        return std::span{m_buffer};
     }
 
     static Message ToMessage(StructuredBuffer&& buffer)
@@ -212,7 +212,7 @@ public:
 class ConnectResponse: public StructuredBuffer<proxy_wifi_connect_response, WIFI_OP_CONNECT_RESPONSE>
 {
 public:
-    ConnectResponse(WlanStatus resultCode, gsl::span<const uint8_t, c_wlan_bssid_len> bssid, uint64_t sessionId)
+    ConnectResponse(WlanStatus resultCode, std::span<const uint8_t, c_wlan_bssid_len> bssid, uint64_t sessionId)
     {
         get()->result_code = WI_EnumValue(resultCode);
         memcpy_s(get()->bssid, sizeof get()->bssid, bssid.data(), bssid.size());
@@ -273,7 +273,7 @@ public:
         get()->scan_complete = scanComplete;
     }
 
-    gsl::span<uint8_t> getIes() const
+    std::span<uint8_t> getIes() const
     {
         return m_ies;
     }
@@ -286,7 +286,7 @@ public:
     }
 
 private:
-    gsl::span<uint8_t> m_ies;
+    std::span<uint8_t> m_ies;
 };
 
 /// @brief Builder class to create a scan response

--- a/lib/OperationHandler.cpp
+++ b/lib/OperationHandler.cpp
@@ -3,7 +3,7 @@
 
 #include "OperationHandler.hpp"
 
-#include <gsl/span>
+#include <span>
 
 #include "GuidUtils.hpp"
 #include "ProxyWifi/Logs.hpp"
@@ -471,7 +471,7 @@ ScanResponse OperationHandler::HandleScanRequestSerialized(const ScanRequest& sc
     OnGuestScanRequest();
 
     auto requestedSsid =
-        scanRequest->ssid_len > 0 ? std::make_optional<const Ssid>(gsl::span{scanRequest->ssid, scanRequest->ssid_len}) : std::nullopt;
+        scanRequest->ssid_len > 0 ? std::make_optional<const Ssid>(std::span{scanRequest->ssid, scanRequest->ssid_len}) : std::nullopt;
 
     // Start all scan requests
     using FutureScanResult = std::future<IWlanInterface::ScanResult>;

--- a/lib/SocketHelpers.cpp
+++ b/lib/SocketHelpers.cpp
@@ -6,7 +6,7 @@
 #include <MSWSock.h>
 
 #include <memory>
-#include <gsl/span>
+#include <span>
 
 #include "ProxyWifi/Logs.hpp"
 
@@ -98,7 +98,7 @@ AcceptAsyncContext AcceptAsyncContext::Accept(const wil::unique_socket& listenSo
     return AcceptAsyncContext(std::move(acceptSocket), std::move(acceptEvent), std::move(buffer), std::move(overlapped));
 }
 
-static bool ReceiveBytes(const wil::unique_socket& socket, gsl::span<uint8_t> buffer)
+static bool ReceiveBytes(const wil::unique_socket& socket, std::span<uint8_t> buffer)
 {
     while (buffer.size_bytes() > 0)
     {
@@ -160,7 +160,7 @@ std::optional<Message> ReceiveProxyWifiMessage(const wil::unique_socket& socket)
     return message;
 }
 
-static void SendBytes(wil::unique_socket& socket, gsl::span<const uint8_t> dataToSend)
+static void SendBytes(wil::unique_socket& socket, std::span<const uint8_t> dataToSend)
 {
     while (dataToSend.size_bytes() > 0)
     {

--- a/lib/TestWlanInterface.cpp
+++ b/lib/TestWlanInterface.cpp
@@ -145,8 +145,8 @@ std::future<IWlanInterface::ScanResult> TestWlanInterface::Scan(std::optional<co
             L"ChannelCenterFreq: %d",
             BssidToString(fakeBss.bssid).c_str(),
             SsidToLogString(fakeBss.ssid.value()).c_str(),
-            ListEnumToHexString(gsl::span{fakeBss.akmSuites}).c_str(),
-            ListEnumToHexString(gsl::span{fakeBss.cipherSuites}).c_str(),
+            ListEnumToHexString(std::span{fakeBss.akmSuites}).c_str(),
+            ListEnumToHexString(std::span{fakeBss.cipherSuites}).c_str(),
             fakeBss.groupCipher ? WI_EnumValue(*fakeBss.groupCipher) : 0,
             fakeBss.channelCenterFreq);
 
@@ -248,8 +248,8 @@ void TestWlanInterface::NotificationSender()
                     L"ChannelCenterFreq: %d",
                     BssidToString(fakeBss.bssid).c_str(),
                     SsidToLogString(fakeBss.ssid.value()).c_str(),
-                    ListEnumToHexString(gsl::span{fakeBss.akmSuites}).c_str(),
-                    ListEnumToHexString(gsl::span{fakeBss.cipherSuites}).c_str(),
+                    ListEnumToHexString(std::span{fakeBss.akmSuites}).c_str(),
+                    ListEnumToHexString(std::span{fakeBss.cipherSuites}).c_str(),
                     fakeBss.groupCipher ? WI_EnumValue(*fakeBss.groupCipher) : 0,
                     fakeBss.channelCenterFreq);
 

--- a/lib/WlanSvcHelpers.cpp
+++ b/lib/WlanSvcHelpers.cpp
@@ -100,7 +100,7 @@ bool IsNullBssid(const DOT11_MAC_ADDRESS& bssid)
     return memcmp(&nullBssid, &bssid, sizeof(DOT11_MAC_ADDRESS)) == 0;
 }
 
-std::pair<DOT11_BSSID_LIST*, std::unique_ptr<uint8_t[]>> BuildBssidList(gsl::span<const DOT11_MAC_ADDRESS> bssids)
+std::pair<DOT11_BSSID_LIST*, std::unique_ptr<uint8_t[]>> BuildBssidList(std::span<const DOT11_MAC_ADDRESS> bssids)
 {
     auto buffer = std::make_unique<uint8_t[]>(sizeof(DOT11_BSSID_LIST) + bssids.size() * sizeof(DOT11_MAC_ADDRESS));
     auto* pBssidList = reinterpret_cast<DOT11_BSSID_LIST*>(buffer.get());
@@ -266,7 +266,7 @@ std::wstring ProfileNameFromSSID(const Ssid& ssid)
     }
 }
 
-std::wstring MakeConnectionProfile(const Ssid& ssid, DOT11_AUTH_CIPHER_PAIR authCipher, const gsl::span<const uint8_t>& key)
+std::wstring MakeConnectionProfile(const Ssid& ssid, DOT11_AUTH_CIPHER_PAIR authCipher, const std::span<const uint8_t>& key)
 {
     std::wostringstream profileXmlBuilder;
     profileXmlBuilder << L"<?xml version=\"1.0\"?>\r\n"
@@ -322,7 +322,7 @@ bool IsAuthCipherPairSupported(const std::pair<DOT11_AUTH_ALGORITHM, DOT11_CIPHE
 }
 
 namespace {
-std::vector<DOT11_CIPHER_ALGORITHM> ConvertCipherSuites(gsl::span<const CipherSuite> ciphers)
+std::vector<DOT11_CIPHER_ALGORITHM> ConvertCipherSuites(std::span<const CipherSuite> ciphers)
 {
     if (ciphers.empty())
     {
@@ -333,7 +333,7 @@ std::vector<DOT11_CIPHER_ALGORITHM> ConvertCipherSuites(gsl::span<const CipherSu
     return r;
 }
 
-constexpr DOT11_AUTH_ALGORITHM DetermineAuth(AuthAlgo auth, uint8_t wpaVersion, gsl::span<const AkmSuite> akms)
+constexpr DOT11_AUTH_ALGORITHM DetermineAuth(AuthAlgo auth, uint8_t wpaVersion, std::span<const AkmSuite> akms)
 {
     if (auth == AuthAlgo::OpenSystem)
     {

--- a/lib/WlanSvcHelpers.hpp
+++ b/lib/WlanSvcHelpers.hpp
@@ -5,13 +5,12 @@
 #include <algorithm>
 #include <memory>
 #include <utility>
+#include <span>
 #include <string>
 
 #include <Windows.h>
 #include <wlanapi.h>
 #include <wlantypes.h>
-
-#include <gsl/span>
 
 #include "Iee80211Utils.hpp"
 
@@ -26,7 +25,7 @@ bool IsNullBssid(const DOT11_MAC_ADDRESS& bssid);
 
 /// @brief Build a DOT11_BSSID_LIST from a list of BSSIDs
 /// @return A pointer to the created DOT11_BSSID_LIST and a smart pointer to the memory allocated for it
-std::pair<DOT11_BSSID_LIST*, std::unique_ptr<uint8_t[]>> BuildBssidList(gsl::span<const DOT11_MAC_ADDRESS> bssids);
+std::pair<DOT11_BSSID_LIST*, std::unique_ptr<uint8_t[]>> BuildBssidList(std::span<const DOT11_MAC_ADDRESS> bssids);
 
 /// @brief Map a 802.11 cipher suite to the corresponding Windows API enumeration
 DOT11_CIPHER_ALGORITHM CipherSuiteToWindowsEnum(CipherSuite cipherSuite);
@@ -55,7 +54,7 @@ std::wstring CipherAlgoToProfileString(DOT11_CIPHER_ALGORITHM cipher);
 std::wstring ProfileNameFromSSID(const Ssid& ssid);
 
 /// @brief Build a valid, basic, wlan profile from the parameters
-std::wstring MakeConnectionProfile(const Ssid& ssid, DOT11_AUTH_CIPHER_PAIR authCipher, const gsl::span<const uint8_t>& key);
+std::wstring MakeConnectionProfile(const Ssid& ssid, DOT11_AUTH_CIPHER_PAIR authCipher, const std::span<const uint8_t>& key);
 
 /// @brief Determine whether an authentication/cipher is supported by the lib for real host connections
 bool IsAuthCipherPairSupported(const std::pair<DOT11_AUTH_ALGORITHM, DOT11_CIPHER_ALGORITHM>& authCipher);

--- a/test/TestOpHandler.cpp
+++ b/test/TestOpHandler.cpp
@@ -101,11 +101,11 @@ TEST_CASE("Process a scan requests", "[wlansvcOpHandler]")
         CHECK(Mock::c_openNetwork.bss.bssid == toBssid(scanResponse->bss[1].bssid));
 
         // The IE are correct
-        gsl::span<uint8_t> ie0{
+        std::span<uint8_t> ie0{
             reinterpret_cast<uint8_t*>(&scanResponse->bss[0]) + scanResponse->bss[0].ie_offset, scanResponse->bss[0].ie_size};
         CHECK(std::equal(ie0.begin(), ie0.end(), Mock::c_wpa2PskNetwork.bss.ies.begin(), Mock::c_wpa2PskNetwork.bss.ies.end()));
 
-        gsl::span<uint8_t> ie1{
+        std::span<uint8_t> ie1{
             reinterpret_cast<uint8_t*>(&scanResponse->bss[1]) + scanResponse->bss[1].ie_offset, scanResponse->bss[1].ie_size};
         CHECK(std::equal(ie1.begin(), ie1.end(), Mock::c_openNetwork.bss.ies.begin(), Mock::c_openNetwork.bss.ies.end()));
     }
@@ -125,7 +125,7 @@ TEST_CASE("Process a scan requests", "[wlansvcOpHandler]")
         CHECK(Mock::c_enterpriseNetwork.bss.bssid == toBssid(scanResponse->bss[0].bssid));
 
         // Check the ie are not the original ones, but are for a WPA2PSK network with the same SSID
-        gsl::span<uint8_t> ie{
+        std::span<uint8_t> ie{
             reinterpret_cast<uint8_t*>(&scanResponse->bss[0]) + scanResponse->bss[0].ie_offset, scanResponse->bss[0].ie_size};
         CHECK(!std::equal(ie.begin(), ie.end(), Mock::c_enterpriseNetwork.bss.ies.begin(), Mock::c_enterpriseNetwork.bss.ies.end()));
         CHECK(
@@ -156,7 +156,7 @@ TEST_CASE("Process a scan requests", "[wlansvcOpHandler]")
         CHECK(scanResponse->scan_complete == 1);
         CHECK(toBssid(bssid) == toBssid(scanResponse->bss[0].bssid));
         // Check the ie are not the original ones, but are for a WPA2PSK network with the same SSID
-        gsl::span<uint8_t> ie{
+        std::span<uint8_t> ie{
             reinterpret_cast<uint8_t*>(&scanResponse->bss[0]) + scanResponse->bss[0].ie_offset, scanResponse->bss[0].ie_size};
         CHECK(std::search(ie.begin(), ie.end(), ssid.value().begin(), ssid.value().end()) != ie.end());
         CHECK(std::search(ie.begin(), ie.end(), Mock::c_wpa2pskRsnIe.begin(), Mock::c_wpa2pskRsnIe.end()) != ie.end());
@@ -305,7 +305,7 @@ TEST_CASE("Handle scan on multiple interfaces", "[wlansvcOpHandler][multiInterfa
         CHECK(toBssid(scanResponse->bss[0].bssid) == Mock::c_wpa2PskNetwork.bss.bssid);
         CHECK(toBssid(scanResponse->bss[1].bssid) == Mock::c_openNetwork.bss.bssid);
         // Check the SSID correspond to the user provided network
-        gsl::span<uint8_t> ie{
+        std::span<uint8_t> ie{
             reinterpret_cast<uint8_t*>(&scanResponse->bss[0]) + scanResponse->bss[0].ie_offset, scanResponse->bss[0].ie_size};
         CHECK(std::search(ie.begin(), ie.end(), ssid.value().begin(), ssid.value().end()) != ie.end());
     }

--- a/test/TestUtils.cpp
+++ b/test/TestUtils.cpp
@@ -8,6 +8,7 @@
 
 #include <sysinfoapi.h>
 
+#include <array>
 #include <chrono>
 using namespace std::chrono_literals;
 
@@ -59,12 +60,26 @@ TEST_CASE("ListEnumToHexString format correctly", "[stringUtils]")
         Peperoni
     };
 
-    CHECK(ListEnumToHexString(gsl::span{std::vector{Breakfast::Croissant, Breakfast::Chocolatine}}) == std::wstring(L"abc11100 def22200"));
-    CHECK(ListEnumToHexString(gsl::span{std::vector{Breakfast::Coffee}}) == std::wstring(L"abcdef00"));
-    CHECK(ListEnumToHexString(gsl::span{std::vector<Breakfast>{}}) == std::wstring(L""));
-
-    CHECK(ListEnumToHexString(gsl::span{std::vector{Pizza::Cheese}}, L"-", 4) == std::wstring(L"0000"));
-    CHECK(ListEnumToHexString(gsl::span{std::vector{Pizza::Peperoni, Pizza::Cheese}}, L"-", 4) == std::wstring(L"0001-0000"));
+    {
+        auto a = std::array{Breakfast::Croissant, Breakfast::Chocolatine};
+        CHECK(ListEnumToHexString(std::span(a)) == std::wstring(L"abc11100 def22200"));
+    }
+    {
+        auto v = std::vector{Breakfast::Coffee};
+        CHECK(ListEnumToHexString(std::span(v)) == std::wstring(L"abcdef00"));
+    }
+    {
+        auto a = std::vector<Breakfast>{};
+        CHECK(ListEnumToHexString(std::span(a)) == std::wstring(L""));
+    }
+    {
+        auto v = std::vector{Pizza::Cheese};
+        CHECK(ListEnumToHexString(std::span(v), L"-", 4) == std::wstring(L"0000"));
+    }
+    {
+        auto v = std::vector{Pizza::Peperoni, Pizza::Cheese};
+        CHECK(ListEnumToHexString(std::span(v), L"-", 4) == std::wstring(L"0001-0000"));
+    }
 }
 
 TEST_CASE("Dynamic function basic behavior works", "[dynamicFunction]")

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -19,7 +19,6 @@ target_include_directories(proxy-wifi-util
 target_link_libraries(proxy-wifi-util
     INTERFACE
         rpcrt4.lib
-        GSL
         WIL
 )
 

--- a/util/DynamicFunction.hpp
+++ b/util/DynamicFunction.hpp
@@ -5,6 +5,7 @@
 #include <libloaderapi.h>
 #include <wil/resource.h>
 #include <functional>
+#include <string>
 
 template <class T>
 class DynamicFunction;

--- a/util/StringUtils.hpp
+++ b/util/StringUtils.hpp
@@ -5,8 +5,8 @@
 #include <codecvt>
 #include <iomanip>
 #include <locale>
+#include <span>
 #include <string>
-#include <gsl/span>
 #include <sstream>
 
 #include <Windows.h>
@@ -14,7 +14,7 @@
 
 /// @brief Allow to convert a buffer of bytes as a string of hexadecimal two-digit values
 /// @example [8, 10, 20] -> "080a14"
-inline static void AppendByteBufferAsHexString(std::wostringstream& stream, const gsl::span<const uint8_t>& byteBuffer)
+inline static void AppendByteBufferAsHexString(std::wostringstream& stream, const std::span<const uint8_t>& byteBuffer)
 {
     stream << std::hex << std::setfill(L'0');
     for (const auto& byte : byteBuffer)
@@ -24,7 +24,7 @@ inline static void AppendByteBufferAsHexString(std::wostringstream& stream, cons
     stream << std::dec << std::setfill(L' ');
 }
 
-inline static std::wstring ByteBufferToHexString(const gsl::span<const uint8_t>& byteBuffer)
+inline static std::wstring ByteBufferToHexString(const std::span<const uint8_t>& byteBuffer)
 {
     std::wostringstream stream;
     AppendByteBufferAsHexString(stream, byteBuffer);
@@ -59,7 +59,7 @@ inline static std::wstring GuidToString(const GUID& guid) noexcept
 
 /// @brief Convert a bssid to a string, as hexadecimal
 /// @example [216, 236, 94, 16, 126, 22] -> "d8:ec:5e:10:7e:16"
-inline static std::wstring BssidToString(const gsl::span<const uint8_t, 6> bssid)
+inline static std::wstring BssidToString(const std::span<const uint8_t, 6> bssid)
 {
     std::wostringstream stream;
     stream << std::hex << std::setfill(L'0');
@@ -76,7 +76,7 @@ inline static std::wstring BssidToString(const gsl::span<const uint8_t, 6> bssid
 /// @brief Convert a ssid to a string for *logging only*, with ASCII and hexadecimal representations
 /// If the ssid isn't an ascii string, invalid character will be replaced by '?'
 /// @example ['m', 'y', ' ', 'w', 'i', 'f', 'i'] -> "'my wifi' [226422226d792077696669]"
-inline static std::wstring SsidToLogString(const gsl::span<const uint8_t> ssid)
+inline static std::wstring SsidToLogString(const std::span<const uint8_t> ssid)
 {
     std::wostringstream stream;
     stream << L"'" << std::wstring{ssid.begin(), ssid.end()} << L"' [";
@@ -90,8 +90,8 @@ inline static std::wstring SsidToLogString(const gsl::span<const uint8_t> ssid)
     return stream.str();
 }
 
-template <class T, std::enable_if_t<std::is_enum_v<T>, int> = 1>
-inline static std::wstring ListEnumToHexString(const gsl::span<T> list, std::wstring_view sep = L" ", int width = 8)
+template <class T, std::size_t Extent, std::enable_if_t<std::is_enum_v<T>, int> = 1>
+inline static std::wstring ListEnumToHexString(const std::span<T, Extent> list, std::wstring_view sep = L" ", int width = 8)
 {
     if (list.empty())
     {


### PR DESCRIPTION
### Goals

This PR fixes build issue when using the version 22621 of the SDK and the version 14.34.31933 of Visual Studio.

### Technical Details

- Use `std::span` instead of `gsl::span` and remove the dependency on GSL.
- Conversion from a r-value to a span is having issue: use a l-value in test to fix compilation
- Update the CI to compile on both SDK 19041 and 22621

### Testing

Unit test runs

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formatted with clang-format
- [x] Newly added code include doxygen-style comments
- [x] Unit tests are succeeding
