### PR TITLE
Update codeQL action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       uses: github/codeql-action/analyze@v3
 
     - name: Collect test artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: proxy-wifi-test-${{ matrix.arch }}-${{ matrix.build_type }}
         path: build/test/${{ matrix.build_type }}/proxy-wifi-test.exe
@@ -66,7 +66,7 @@ jobs:
     steps:
     - name: Download test artifact
       id: download
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: proxy-wifi-test-x64-Debug
 
@@ -74,7 +74,7 @@ jobs:
       run: ${{steps.download.outputs.download-path}}/proxy-wifi-test.exe -s >> test-logs.txt
 
     - name: Collect test logs on failure
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: test-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Initialize CodeQL
       if: ${{ matrix.codeql }}
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: cpp
 
@@ -52,7 +52,7 @@ jobs:
 
     - name: Perform CodeQL Analysis
       if: ${{ matrix.codeql }}
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
 
     - name: Collect test artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Initialize CodeQL
       if: ${{ matrix.codeql }}
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: cpp
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Collect test artifact
       uses: actions/upload-artifact@v4
       with:
-        name: proxy-wifi-test-${{ matrix.arch }}-${{ matrix.build_type }}
+        name: proxy-wifi-test-${{ matrix.arch }}-${{ matrix.build_type }}-${{ matrix.sdk_version }}
         path: build/test/${{ matrix.build_type }}/proxy-wifi-test.exe
 
   run_unit_tests:
@@ -68,7 +68,7 @@ jobs:
       id: download
       uses: actions/download-artifact@v4
       with:
-        name: proxy-wifi-test-x64-Debug
+        name: proxy-wifi-test-x64-Debug-19041
 
     - name: Run tests
       run: ${{steps.download.outputs.download-path}}/proxy-wifi-test.exe -s >> test-logs.txt


### PR DESCRIPTION
### Goals

The codeQL action version must be V3 (V1 was deprecated, V2 is about to be deprecated).

### Checklist

- [x] All targets compile successfully
- [x] Changes have been formatted with clang-format
- [x] Newly added code include doxygen-style comments
- [x] Unit tests are succeeding
